### PR TITLE
Allow an API client to delete files 

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -24,16 +24,16 @@ module MojFile
     end
 
     post '/?:collection_ref?/new' do |collection_ref|
-      @add = Add.new(collection_ref: collection_ref,
+      add = Add.new(collection_ref: collection_ref,
                      params: body_params)
 
-      if @add.valid?
-        @add.upload
+      if add.valid?
+        add.upload
         status(200)
-        body({ collection: @add.collection, key: @add.file_key }.to_json)
+        body({ collection: add.collection, key: add.file_key }.to_json)
       else
         status(422) # Unprocessable entity
-        return({ errors: @add.errors }.to_json)
+        body({ errors: add.errors }.to_json)
       end
     end
 

--- a/app.rb
+++ b/app.rb
@@ -37,6 +37,11 @@ module MojFile
       end
     end
 
+    delete '/:collection_ref/:filename' do |collection_ref, filename|
+      Delete.delete!(collection: collection_ref, file: filename)
+      status(204)
+    end
+
     helpers do
       def body_params
         JSON.parse(request.body.read)

--- a/lib/moj_file.rb
+++ b/lib/moj_file.rb
@@ -1,6 +1,8 @@
 require 'aws-sdk'
 require_relative 'moj_file/s3'
+
 require_relative 'moj_file/add'
+require_relative 'moj_file/delete'
 require_relative 'moj_file/list'
 
 module MojFile

--- a/lib/moj_file/delete.rb
+++ b/lib/moj_file/delete.rb
@@ -1,0 +1,31 @@
+module MojFile
+  class Delete
+    include MojFile::S3
+
+    attr_accessor :collection,
+      :file
+
+    def self.delete!(*args)
+      new(*args).delete!
+    end
+
+    def initialize(collection:, file:)
+      @collection = collection
+      @file = file
+    end
+
+    def delete!
+      object.delete
+    end
+
+    private
+
+    def bucket_name
+      ENV.fetch('BUCKET_NAME')
+    end
+
+    def object
+      s3.bucket(bucket_name).object([collection, file].join('/'))
+    end
+  end
+end

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -1,0 +1,12 @@
+The specs in this directory are pseudo-features (or duck-features, if
+you like)–they test the full using Rack::Test, but do not rely on the
+Capybara features functionality. This is because they need to make
+requests using something other than `visit|get`.
+
+They are described using the class names of the underlying classed in
+order to ensure that mutation testing can find all of them. If they are
+named in a more feature-esq way (i.e. `RSpec.feature 'Add a file'` or
+`RSpec.describe 'Add a file'`), then mutant does not use all of them
+when killing mutants. See [the explaination of mutant test
+selection](https://github.com/mbj/mutant#test-selection) for more
+details.

--- a/spec/features/README.md
+++ b/spec/features/README.md
@@ -1,11 +1,11 @@
 The specs in this directory are pseudo-features (or duck-features, if
-you like)–they test the full using Rack::Test, but do not rely on the
+you like)–they test the implementation using Rack::Test, but do not rely on the
 Capybara features functionality. This is because they need to make
 requests using something other than `visit|get`.
 
-They are described using the class names of the underlying classed in
+They are described using the class names of the underlying classes in
 order to ensure that mutation testing can find all of them. If they are
-named in a more feature-esq way (i.e. `RSpec.feature 'Add a file'` or
+named in a more feature-esqe way (e.g. `RSpec.feature 'Add a file'` or
 `RSpec.describe 'Add a file'`), then mutant does not use all of them
 when killing mutants. See [the explaination of mutant test
 selection](https://github.com/mbj/mutant#test-selection) for more

--- a/spec/features/delete_a_file_spec.rb
+++ b/spec/features/delete_a_file_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+RSpec.describe MojFile::Delete do
+  context 'the file exists' do
+    let!(:s3_stub) {
+      stub_request(:delete, /uploader-test-bucket.+amazonaws\.com\/ABC123\/testfile\.docx/).
+      to_return(status: 204)
+    }
+
+    describe '#delete' do
+      before do
+        delete '/ABC123/testfile.docx'
+      end
+
+      describe 'it deletes the file' do
+        it { expect(s3_stub).to have_been_requested }
+        # This mirrors S3's success response.
+        it { expect(last_response.status).to eq(204) }
+      end
+    end
+  end
+
+  describe 'the file does not exist' do
+    let!(:s3_stub) {
+      stub_request(:delete, /uploader-test-bucket.+amazonaws\.com\/ABC123\/nofile\.docx/).
+      to_return(status: 204)
+    }
+
+    describe '#delete' do
+      before do
+        delete '/ABC123/nofile.docx'
+      end
+
+      describe 'it appears to delete the file' do
+        it { expect(s3_stub).to have_been_requested }
+        it { expect(last_response.status).to eq(204) }
+      end
+    end
+  end
+
+  describe 'neither collection nor file exists' do
+    let!(:s3_stub) {
+      stub_request(:delete, /uploader-test-bucket.+amazonaws\.com\/123ABC\/nofile\.docx/).
+      to_return(status: 204)
+    }
+
+    describe '#delete' do
+      before do
+        delete '/123ABC/nofile.docx'
+      end
+
+      describe 'it appears to delete the file' do
+        it { expect(s3_stub).to have_been_requested }
+        it { expect(last_response.status).to eq(204) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the simplest possible implementation. 

It can be configured to check for the existence of a file and I am aware the spec outlines this behaviour.  I'm not sure it needs to, though.  TBD. 