### PR TITLE
Keep viruses off the system

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ cp .env.example .env
 docker-compose build
 docker-compose up
 ```
+
+## Scanner endpoint
+
+If the virus scanner is not available from this appication at
+`http://clamav-rest:8080/scan` then you will need to set the
+`SCANNER_URL` environment variable to point at the correct endpoint.  It
+*should* be available if the app is launched using docker compose.
+
 ## Run outside docker
 
 ```bash

--- a/app.rb
+++ b/app.rb
@@ -27,10 +27,13 @@ module MojFile
       add = Add.new(collection_ref: collection_ref,
                      params: body_params)
 
-      if add.valid?
+      if add.valid? && add.scan_clear?
         add.upload
         status(200)
         body({ collection: add.collection, key: add.file_key }.to_json)
+      elsif !add.scan_clear?
+        status(400)
+        body({ errors: ['Virus scan failed'] }.to_json)
       else
         status(422) # Unprocessable entity
         body({ errors: add.errors }.to_json)

--- a/lib/moj_file.rb
+++ b/lib/moj_file.rb
@@ -4,6 +4,7 @@ require_relative 'moj_file/s3'
 require_relative 'moj_file/add'
 require_relative 'moj_file/delete'
 require_relative 'moj_file/list'
+require_relative 'moj_file/scan'
 
 module MojFile
 end

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -29,11 +29,19 @@ module MojFile
       errors.empty?
     end
 
+    def scan_clear?
+      scan.scan_clear?
+    end
+
     def file_key
       @file_key ||= "#{SecureRandom.uuid}.#{title}#{original_extension}"
     end
 
     private
+
+    def scan
+      Scan.new(filename: filename, data: file_data)
+    end
 
     def bucket_name
       ENV.fetch('BUCKET_NAME')

--- a/lib/moj_file/dummy_path.rb
+++ b/lib/moj_file/dummy_path.rb
@@ -1,0 +1,14 @@
+# RestClient won’t treat a StringIO object as a file for the purpose of
+# a multipart form field, as StringIO doesn’t respond to `#path`.
+# This works around this problem by including a dummy path method.
+# The return value of this method does not matter.  It has been set to such to
+# avoid new-to-the-project developer confusion when looking at response values
+# and the like.
+
+module MojFile
+  class DummyPath < StringIO
+    def path
+      'DOES NOT MATTER'
+    end
+  end
+end

--- a/lib/moj_file/scan.rb
+++ b/lib/moj_file/scan.rb
@@ -1,0 +1,26 @@
+require 'rest_client'
+require_relative 'dummy_path'
+
+module MojFile
+  class Scan
+    # clamav-rest is remapped in docker-compose.yml
+    SCANNER_URL = 'http://clamav-rest:8080/scan'.freeze
+
+    attr_accessor :filename, :data
+
+    def initialize(filename:, data:)
+      @filename = filename
+      @data = DummyPath.new(data)
+    end
+
+    def scan_clear?
+      post.body.eql?("Everything ok : true\n")
+    end
+
+    private
+
+    def post
+      RestClient.post(SCANNER_URL, name: filename, file: data, multipart: true)
+    end
+  end
+end

--- a/lib/moj_file/scan.rb
+++ b/lib/moj_file/scan.rb
@@ -4,7 +4,7 @@ require_relative 'dummy_path'
 module MojFile
   class Scan
     # clamav-rest is remapped in docker-compose.yml
-    SCANNER_URL = 'http://clamav-rest:8080/scan'.freeze
+    SCANNER_URL = ENV.fetch('SCANNER_URL', 'http://clamav-rest:8080/scan').freeze
 
     attr_accessor :filename, :data
 

--- a/spec/features/add_a_file_spec.rb
+++ b/spec/features/add_a_file_spec.rb
@@ -18,11 +18,24 @@ RSpec.describe MojFile::Add do
       with(body: "RW5jb2RlZCBkb2N1bWVudCBib2R5\n")
   }
 
+  let!(:av_stub) {
+    # Ideally, I would match the request body for filename and data.  This
+    # would remove the need for unit tests for these specific attributes.
+    # However, webmock does not yet support this for multipart requests.
+    stub_request(:post, "http://clamav-rest:8080/scan").
+      to_return(body: "Everything ok : true\n")
+  }
+
   context 'successfully adding a file' do
     context 'generating a new collection_reference' do
       it 'uploads the file to s3' do
         post '/new', params.to_json
         expect(s3_stub).to have_been_requested
+      end
+
+      it 'sends the file file to the av service for scanning' do
+        post '/new', params.to_json
+        expect(av_stub).to have_been_requested
       end
 
       it 'returns a 200' do

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe MojFile::Add do
+  let(:params) {
+    {
+      'file_title' => 'Test Upload',
+      'file_filename' => 'testfile.docx',
+      'file_data' =>  Base64.encode64('Encoded document body')
+    }
+  }
+
+  describe '#scan_clear?' do
+    before do
+      scan = instance_double(MojFile::Scan)
+      expect(scan).to receive(:scan_clear?)
+      expect(MojFile::Scan).to receive(:new).
+        with(filename: params['file_filename'], data: params['file_data']).
+        and_return(scan)
+    end
+
+    it 'calls MojFile::Scan' do
+      described_class.new(collection_ref: nil, params: params).scan_clear?
+    end
+  end
+end

--- a/spec/lib/moj_file/scan_spec.rb
+++ b/spec/lib/moj_file/scan_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+RSpec.describe MojFile::Scan do
+  let(:params) {
+    {
+      filename: 'testfile.docx',
+      data: Base64.encode64('Encoded document body')
+    }
+  }
+
+  let!(:rest_client_stub) {
+    allow(RestClient).to receive(:post)
+  }
+
+  let(:resp) { instance_double(RestClient::Response, body: "Everything ok : true\n") }
+
+  describe '#scan_clear?' do
+    before do
+      allow(RestClient).to receive(:post).and_return(resp)
+    end
+
+    context 'clear' do
+      before do
+        expect(resp).to receive(:body).and_return("Everything ok : true\n")
+      end
+
+      it 'returns true' do
+        expect(
+          described_class.
+            new(filename: params[:filename], data: params[:data]).scan_clear?
+        ).to be_truthy
+      end
+    end
+
+    context 'infected' do
+      before do
+        expect(resp).to receive(:body).and_return("Everything ok : false\n")
+      end
+
+      it 'returns false' do
+        expect(
+          described_class.
+            new(filename: params[:filename], data: params[:data]).scan_clear?
+        ).to be_falsey
+      end
+    end
+
+    context 'RestClient' do
+      subject(:scan_file) {
+        described_class.new(filename: params[:filename], data: params[:data]).
+        scan_clear?
+      }
+
+      let(:rest_client_called) { expect(RestClient).to receive(:post) }
+
+      it 'is called with the correct endpoint' do
+        rest_client_called.with(MojFile::Scan::SCANNER_URL, anything).
+          and_return(resp)
+        scan_file
+      end
+
+      it 'is called with the filename' do
+        rest_client_called.
+          with(anything, hash_including(name: params[:filename])).
+          and_return(resp)
+        scan_file
+      end
+
+      it 'is called with the data/content of the file' do
+        rest_client_called.
+          with(anything, hash_including(file: instance_of(MojFile::DummyPath))).
+          and_return(resp)
+        scan_file
+      end
+
+      it 'uses multipart' do
+        rest_client_called.
+          with(anything, hash_including(multipart: true)).
+          and_return(resp)
+        scan_file
+      end
+
+      it 'captures the response body from the post' do
+        expect(resp).to receive(:body).and_return("Everything ok : true\n")
+        rest_client_called.and_return(resp)
+        scan_file
+      end
+    end
+  end
+
+  context 'DummyPath' do
+    # RestClient won’t do multipart unless it thinks it is dealing with a
+    # filesystem object.  DummyPath is a simple way of making it work by
+    # associating a path with the StringIo object.
+    it 'sets up a dummy filename for multipart' do
+      expect(MojFile::DummyPath).to receive(:new).with(params[:data])
+      described_class.new(filename: params[:filename], data: params[:data])
+    end
+  end
+end


### PR DESCRIPTION
Exactly what it says in the title–this is an implementation of the
scanning service/container client from the prototype.  It calls a
container running ClamAV and halts the upload if a virus is found.
