### PR TITLE
Fix Docker quit-on-start issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-FROM ruby:2.3.1
-# RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
-RUN mkdir /app
-WORKDIR /app
-ADD Gemfile /app/Gemfile
-ADD Gemfile.lock /app/Gemfile.lock
-RUN bundle install
-ADD . /app
+FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
+
+ENV PUMA_PORT 9292
+ENV RACK_ENV production
+
+RUN touch /etc/inittab
+
+RUN rm /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update && apt-get install -y
+
+EXPOSE $PUMA_PORT
+
+ENTRYPOINT ["./run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd /usr/src/app
+echo "Running app"
+bundle exec puma -p $PUMA_PORT


### PR DESCRIPTION
This was using the old file that CW put in place that does not actually
run the app; it only runs irb.  YZ could not get it to run in production
as irb was stopping as soon as it started. This caused the container to
die.