### PR TITLE
Stop the uploader breaking in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 source 'https://rubygems.org'
 
 gem 'aws-sdk'
+gem 'logstash-logger'
 gem 'pry'
 gem 'puma'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,9 @@ GEM
     ice_nine (0.11.2)
     jmespath (1.3.1)
     json (1.8.3)
+    logstash-event (1.2.02)
+    logstash-logger (0.20.0)
+      logstash-event (~> 1.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
@@ -173,6 +176,7 @@ DEPENDENCIES
   brakeman
   capybara
   fuubar
+  logstash-logger
   mutant-rspec
   pry
   pry-byebug
@@ -188,4 +192,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -30,18 +30,28 @@ delete object.
 
 The scripts for easy automation of these tasks can be found in the
 [Mojfile S3 bucket setup repo](https://github.com/ministryofjustice/mojfile-s3-bucket-setup)
-However, those scripts assume that an IAM *user* will authenticate to the S3 bucket. 
+However, those scripts assume that an IAM *user* will authenticate to the S3 bucket.
 In production, IAM *roles* will be used, such that the container in which the application
 is running is granted (or not) appropriate permissions to operate on the S3 bucket.
 
-## Run
+## Note on AWS Credentials
+
+These are no longer needed in production as we now use roles.  They are
+still required if you want to run the application locally.  They are
+picked up automatically by `aws-sdk` if you use the environment
+variables set in `env.example`.
+
+## Run Locally
 
 ```
 cp .env.example .env
-# ... and update the details in that file with the credentials created above
+# update the details in that file with the credentials created above
+# remove the `export` commands
 docker-compose build
 docker-compose up
 ```
+
+It does not need the `.env` file in the production container.
 
 ## Scanner endpoint
 
@@ -53,6 +63,8 @@ If the virus scanner is not available from this appication at
 ## Run outside docker
 
 ```bash
+cp .env.example .env
+# ... and update the details in that file with the credentials created above
 bundle exec rackup
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It does not need the `.env` file in the production container.
 
 ## Scanner endpoint
 
-If the virus scanner is not available from this appication at
+If the virus scanner is not available from this application at
 `http://clamav-rest:8080/scan` then you will need to set the
 `SCANNER_URL` environment variable to point at the correct endpoint.  It
 *should* be available if the app is launched using docker compose.

--- a/app.rb
+++ b/app.rb
@@ -1,10 +1,16 @@
 require 'sinatra'
 require 'json'
+require 'logstash-logger'
 require_relative 'lib/moj_file'
 require 'pry'
 
 module MojFile
   class Uploader < Sinatra::Base
+    configure :production, :development do
+      enable :logging
+      use Rack::CommonLogger, LogStashLogger.new(type: :stdout)
+    end
+
     get '/status' do
       { status: 'OK' }.to_json
     end

--- a/app.rb
+++ b/app.rb
@@ -6,11 +6,6 @@ require 'pry'
 
 module MojFile
   class Uploader < Sinatra::Base
-    configure :production, :development do
-      enable :logging
-      use Rack::CommonLogger, LogStashLogger.new(type: :stdout)
-    end
-
     get '/status' do
       { status: 'OK' }.to_json
     end

--- a/env.example
+++ b/env.example
@@ -1,3 +1,3 @@
-ACCESS_KEY_ID=
-SECRET_ACCESS_KEY=
-BUCKET_NAME=
+export AWS_ACCESS_KEY_ID=dummy key
+export AWS_SECRET_ACCESS_KEY=dummy access key
+export BUCKET_NAME=tax-tribs-doc-upload-test

--- a/lib/moj_file/s3.rb
+++ b/lib/moj_file/s3.rb
@@ -1,14 +1,7 @@
 module MojFile
   module S3
     def s3
-      Aws::S3::Resource.new(
-        credentials:
-          Aws::Credentials.new(
-            ENV.fetch('ACCESS_KEY_ID'),
-            ENV.fetch('SECRET_ACCESS_KEY')
-          ),
-        region: ENV.fetch('AWS_REGION', 'eu-west-1')
-      )
+      Aws::S3::Resource.new(region: ENV.fetch('AWS_REGION', 'eu-west-1'))
     end
   end
 end

--- a/spec/features/list_files_spec.rb
+++ b/spec/features/list_files_spec.rb
@@ -33,12 +33,12 @@ RSpec.describe MojFile::List do
             {
               key: '12345/solicitor.docx',
               title: 'solicitor.docx',
-              last_modified: '2016-10-12 17:50:30 UTC'
+              last_modified: '2016-10-12T17:50:30.000Z'
             },
             {
               key: '12345/hmrc_appeal.docx',
               title: 'hmrc_appeal.docx',
-              last_modified: '2016-10-12 17:50:30 UTC'
+              last_modified: '2016-10-12T17:50:30.000Z'
             }
         ]
         }.to_json

--- a/spec/lib/moj_file/s3_spec.rb
+++ b/spec/lib/moj_file/s3_spec.rb
@@ -8,29 +8,21 @@ RSpec.describe MojFile::S3 do
   }
 
   it 'adds an s3 resource to the class' do
-    allow(ENV).to receive(:fetch).with('ACCESS_KEY_ID')
-    allow(ENV).to receive(:fetch).with('SECRET_ACCESS_KEY')
     allow(ENV).to receive(:fetch).with('AWS_REGION', 'eu-west-1').and_return('eu-west-1')
     expect(object.new.s3).to be_an_instance_of(Aws::S3::Resource)
   end
 
   it 'fetches the access key from the ENV' do
-    expect(ENV).to receive(:fetch).with('ACCESS_KEY_ID')
-    allow(ENV).to receive(:fetch).with('SECRET_ACCESS_KEY')
     allow(ENV).to receive(:fetch).with('AWS_REGION', 'eu-west-1').and_return('eu-west-1')
     object.new.s3
   end
 
   it 'fetches the secret access key from the ENV' do
-    expect(ENV).to receive(:fetch).with('SECRET_ACCESS_KEY')
-    allow(ENV).to receive(:fetch).with('ACCESS_KEY_ID')
     allow(ENV).to receive(:fetch).with('AWS_REGION', 'eu-west-1').and_return('eu-west-1')
     object.new.s3
   end
 
   it 'fetches the region from the ENV and has a default' do
-    expect(ENV).to receive(:fetch).with('SECRET_ACCESS_KEY')
-    allow(ENV).to receive(:fetch).with('ACCESS_KEY_ID')
     expect(ENV).to receive(:fetch).with('AWS_REGION', 'eu-west-1').and_return('eu-west-1')
     object.new.s3
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,16 +24,15 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  #config.before(:each) do
+    #stub_request(:get, /\/latest\/meta-data\/iam\/security-credentials\//).
+      #to_return(:status => 200, :body => "", :headers => {})
+  #end
+
   config.around(:each) do |example|
     original_bucket = ENV['BUCKET_NAME']
-    original_key = ENV['ACCESS_KEY_ID']
-    original_secret= ENV['SECRET_ACCESS_KEY']
     ENV['BUCKET_NAME'] = 'uploader-test-bucket'
-    ENV['ACCESS_KEY_ID'] = 'dummy key'
-    ENV['SECRET_ACCESS_KEY'] = 'dummy secret'
     example.run
     ENV['BUCKET_NAME'] = original_bucket
-    ENV['ACCESS_KEY_ID'] = original_key
-    ENV['SECRET_ACCESS_KEY'] = original_secret
   end
 end


### PR DESCRIPTION
As the keys are no longer required due to our use of roles.  This commit
brings it in line with the downloader.