### PR TITLE
Fix a potential issue when listing files.

### DIFF
--- a/lib/moj_file/list.rb
+++ b/lib/moj_file/list.rb
@@ -29,10 +29,14 @@ module MojFile
       objects.map{ |o|
         {
           key: o.key,
-          title: o.key.sub("#{collection}/",''),
+          title: o.key.sub(prefix,''),
           last_modified: o.last_modified
         }
       }
+    end
+
+    def prefix
+      "#{collection}/"
     end
 
     def bucket_name
@@ -40,7 +44,7 @@ module MojFile
     end
 
     def objects
-      @objects ||= s3.bucket(bucket_name).objects(prefix: collection).to_set
+      @objects ||= s3.bucket(bucket_name).objects(prefix: prefix).to_set
     end
   end
 end

--- a/spec/lib/moj_file/list_spec.rb
+++ b/spec/lib/moj_file/list_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe MojFile::List do
+  let(:collection_ref) { '12345' }
+  let(:s3) { instance_double(Aws::S3::Resource, bucket: bucket) }
+  let(:bucket) { double('Bucket', objects: objects) }
+  let(:objects) { [double('Object', key: '12345/test123.txt', title: '12345/test123.txt', last_modified: '2016-12-01T16:26:44.000Z')] }
+
+  subject { described_class.new(collection_ref) }
+
+  describe '#files' do
+    before do
+      allow(subject).to receive(:s3).and_return(s3)
+    end
+
+    let(:expected_files_hash) {
+      {
+        collection: collection_ref,
+        files: [
+            {key: '12345/test123.txt', title: 'test123.txt', last_modified: '2016-12-01T16:26:44.000Z'}
+        ]
+      }
+    }
+
+    it 'list S3 bucket objects by their collection reference including a trailing slash' do
+      expect(bucket).to receive(:objects).with(prefix: '12345/')
+      files = subject.files
+      expect(files).to eq(expected_files_hash)
+    end
+  end
+end


### PR DESCRIPTION
An issue made possible to query by any prefix, as long as at least 1 character matched
a collection, it would return the files for the whole collection reference.

Example:

Given the collection reference '081da0d2-1865-499d-8197-08f4f2d33741', if calling the endpoint with
just '0' would match the whole collection and return the files.