### PR TITLE
Add dummy env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM ministryofjustice/ruby:2.3.1-webapp-onbuild
 ENV PUMA_PORT 9292
 ENV RACK_ENV production
 
+ENV BUCKET_NAME replace_this_at_build_time
+ENV SCANNER_URL replace_this_at_build_time
+
 RUN touch /etc/inittab
 
 RUN rm /etc/apt/sources.list.d/nodesource.list


### PR DESCRIPTION
Enables jenkins to build the docker image. Dummy values will be
replaced at runtime.