### PR TITLE
Healthcheck av

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -22,6 +22,9 @@ module MojFile
               passed_clean_file: checks[:passed_clean_file]
             },
             s3: {
+              # This is here so ops do not have to go looking for the AWS S3
+              # status if the write_test fails. It does not change the
+              # service_status
               S3::REGION.tr('-','_') => S3.status,
               write_test: checks[:write_test]
             }

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -33,6 +33,19 @@ module MojFile
       scan.scan_clear?
     end
 
+    def self.write_test
+      # It started checking for .success? but that isn't acutually necessary as
+      # anything other than a successful call will raise an exception.
+      new(collection_ref: 'healthcheck',
+          params: {
+        'file_title' => 'Healthcheck Upload',
+        'file_filename' => 'healthcheck.docx',
+        'file_data' => 'QSBkb2N1bWVudCBib2R5' }
+         ).upload
+    rescue Aws::S3::Errors::ServiceError
+      false
+    end
+
     private
 
     def scan

--- a/lib/moj_file/scan.rb
+++ b/lib/moj_file/scan.rb
@@ -8,6 +8,7 @@ module MojFile
     SCANNER_URL = ENV.fetch('SCANNER_URL', 'http://clamav-rest:8080/scan').freeze
     EICAR_TEST = 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
     CLEAN_TEST = 'clear test file'
+    EXPECTED_CLEAR_RESPONSE = "Everything ok : true\n".freeze
 
     attr_reader :filename, :dummy_file
 
@@ -17,15 +18,15 @@ module MojFile
     end
 
     def scan_clear?
-      post.body.match(/true/)
+      post.body.eql?(EXPECTED_CLEAR_RESPONSE)
     end
 
-    def self.trigger_alert
-      new(filename: 'eicar test', data: EICAR_TEST).scan_clear? ? 'FAILED' : 'OK'
+    def self.healthcheck_infected
+      !new(filename: 'eicar test', data: EICAR_TEST).scan_clear?
     end
 
-    def self.clean_file
-      new(filename: 'clean test', data: CLEAN_TEST).scan_clear? ? 'OK' : 'FAILED'
+    def self.healthcheck_clean
+      new(filename: 'clean test', data: CLEAN_TEST).scan_clear?
     end
 
     private

--- a/spec/features/healthcheck/app_spec.rb
+++ b/spec/features/healthcheck/app_spec.rb
@@ -10,14 +10,15 @@ RSpec.describe 'Service status' do
 
   before do
     allow(MojFile::S3).to receive(:status)
-    allow(MojFile::Scan).to receive(:trigger_alert)
-    allow(MojFile::Scan).to receive(:clean_file)
+    allow(MojFile::Scan).to receive(:healthcheck_infected).and_return(true)
+    allow(MojFile::Scan).to receive(:healthcheck_clean).and_return(true)
+    stub_request(:put, /healthcheck\.docx/).to_return(status: 200)
     get '/healthcheck'
   end
 
   describe 'happy path' do
-    it 'reports that the service is OK' do
-      expect(service_status).to eq('OK')
+    it 'reports that the service is ok' do
+      expect(service_status).to eq('ok')
     end
   end
 end

--- a/spec/features/healthcheck/av_spec.rb
+++ b/spec/features/healthcheck/av_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Healthcheck' do
 
   before do
     allow(MojFile::S3).to receive(:status)
+    stub_request(:put, /healthcheck\.docx/).to_return(status: 200)
   end
 
   describe 'happy path' do
@@ -20,40 +21,49 @@ RSpec.describe 'Healthcheck' do
 
       specify do
         get '/healthcheck'
-        expect(av[:detect_infection]).to eq('OK')
+        expect(av[:detected_infected_file]).to eq('ok')
       end
     end
 
     describe 'fails when it should have detected a virus' do
       before do
-        expect(RestClient).to receive(:post).twice.and_return(double('response', body: 'true'))
+        expect(RestClient).
+          to receive(:post).
+          twice.
+          and_return(double('response', body: MojFile::Scan::EXPECTED_CLEAR_RESPONSE))
       end
 
       specify do
         get '/healthcheck'
-        expect(av[:detect_infection]).to eq('FAILED')
+        expect(av[:detected_infected_file]).to eq('failed')
       end
     end
 
     describe 'passes a clean file' do
       before do
-        expect(RestClient).to receive(:post).twice.and_return(double('response', body: 'true'))
+        expect(RestClient).
+          to receive(:post).
+          twice.
+          and_return(double('response', body: MojFile::Scan::EXPECTED_CLEAR_RESPONSE))
       end
 
       specify do
         get '/healthcheck'
-        expect(av[:pass_clean]).to eq('OK')
+        expect(av[:passed_clean_file]).to eq('ok')
       end
     end
 
     describe 'fails when it should have passed a clean file' do
       before do
-        expect(RestClient).to receive(:post).twice.and_return(double('response', body: ''))
+        expect(RestClient).
+          to receive(:post).
+          twice.
+          and_return(double('response', body: ''))
       end
 
       specify do
         get '/healthcheck'
-        expect(av[:pass_clean]).to eq('FAILED')
+        expect(av[:passed_clean_file]).to eq('failed')
       end
     end
   end

--- a/spec/features/healthcheck/s3_spec.rb
+++ b/spec/features/healthcheck/s3_spec.rb
@@ -1,16 +1,80 @@
 require_relative '../../spec_helper'
 
 RSpec.describe 'Healthcheck' do
-  let(:dependencies) {
+  let(:parsed_response) {
     JSON.parse(
       last_response.body,
       symbolize_names: true
-    )[:dependencies]
+    )
+  }
+
+  let(:s3_subkey) {
+    parsed_response[:dependencies][:external][:s3]
   }
 
   before do
-    allow(MojFile::Scan).to receive(:trigger_alert)
-    allow(MojFile::Scan).to receive(:clean_file)
+    allow(MojFile::Scan).to receive(:healthcheck_infected)
+    allow(MojFile::Scan).to receive(:healthcheck_clean)
+  end
+
+  context 'Successful write test' do
+    let(:decoded_file_data) { 'A document body' }
+    let!(:write_stub) {
+      stub_request(:put, /healthcheck\.docx/).
+      with(body: decoded_file_data).
+      to_return(status: 200)
+    }
+
+    before do
+      stub_request(:get, 'https://status.aws.amazon.com/rss/s3-eu-west-1.rss')
+    end
+
+    describe '[:external][:s3][:write_test]' do
+      specify do
+        get '/healthcheck'
+        expect(s3_subkey[:write_test]).to eq('ok')
+      end
+    end
+
+    describe '[:service_status]' do
+      before do
+        allow(MojFile::S3).to receive(:status)
+        allow(MojFile::Scan).to receive(:healthcheck_infected).and_return(true)
+        allow(MojFile::Scan).to receive(:healthcheck_clean).and_return(true)
+      end
+
+      specify do
+        get '/healthcheck'
+        expect(parsed_response[:service_status]).to eq('ok')
+      end
+    end
+  end
+
+  context 'Failed write test' do
+    let(:decoded_file_data) { 'A document body' }
+    let!(:write_stub) {
+      stub_request(:put, /healthcheck\.docx/).
+      with(body: decoded_file_data).
+      to_return(status: 422)
+    }
+
+    before do
+      stub_request(:get, 'https://status.aws.amazon.com/rss/s3-eu-west-1.rss')
+    end
+
+    describe '[:external][:s3][:write_test]' do
+      specify do
+        get '/healthcheck'
+        expect(s3_subkey[:write_test]).to eq('failed')
+      end
+    end
+
+    describe '[:service_status]' do
+      specify do
+        get '/healthcheck'
+        expect(parsed_response[:service_status]).to eq('failed')
+      end
+    end
   end
 
   context 'AWS status endpoint' do
@@ -46,6 +110,10 @@ RSpec.describe 'Healthcheck' do
       XML
     }
 
+    before do
+      stub_request(:put, /healthcheck\.docx/).to_return(status: 200)
+    end
+
     describe 'default region [:external][:s3][:eu_west_1]' do
       before do
         stub_request(:get, "https://status.aws.amazon.com/rss/s3-eu-west-1.rss").
@@ -55,7 +123,7 @@ RSpec.describe 'Healthcheck' do
       describe 'if the endpoint reports that the service is working, the key' do
         specify do
           get '/healthcheck'
-          expect(dependencies[:external][:s3][:eu_west_1]).
+          expect(s3_subkey[:eu_west_1]).
             to eq('Service is operating normally')
         end
       end
@@ -68,8 +136,7 @@ RSpec.describe 'Healthcheck' do
 
         specify do
           get '/healthcheck'
-          expect(dependencies[:external][:s3][:eu_west_1]).
-            to eq('N/A')
+          expect(s3_subkey[:eu_west_1]).to eq('N/A')
         end
       end
     end
@@ -87,7 +154,7 @@ RSpec.describe 'Healthcheck' do
       describe 'if the endpoint reports that the service is working, the key' do
         specify do
           get '/healthcheck'
-          expect(dependencies[:external][:s3][:us_east_1]).
+          expect(s3_subkey[:us_east_1]).
             to eq('Service is operating normally')
         end
       end
@@ -100,8 +167,7 @@ RSpec.describe 'Healthcheck' do
 
         specify do
           get '/healthcheck'
-          expect(dependencies[:external][:s3][:us_east_1]).
-            to eq('N/A')
+          expect(s3_subkey[:us_east_1]).to eq('N/A')
         end
       end
     end

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -25,4 +25,30 @@ RSpec.describe MojFile::Add do
       described_class.new(collection_ref: nil, params: params).scan_clear?
     end
   end
+
+  describe '.write_test' do # These are mutant kills
+    it 'uploads a test file successfully' do
+      stub_request(:put, /\/healthcheck\/healthcheck\.docx/).to_return(status: 200)
+      expect(described_class.write_test).to be_truthy
+    end
+
+    it 'fails to upload a test file' do
+      stub_request(:put, /\/healthcheck\/healthcheck\.docx/).to_return(status: 422)
+      expect(described_class.write_test).to be(false)
+    end
+
+    it 'receives the parameters required for the test file' do
+      response = double(:response, successful?: true)
+      expect(described_class).
+        to receive(:new).
+        with(collection_ref: 'healthcheck',
+             params: {
+                      'file_title' => 'Healthcheck Upload',
+                      'file_filename' => 'healthcheck.docx',
+                      'file_data' => 'QSBkb2N1bWVudCBib2R5'
+                     }
+            ).and_return(instance_double(MojFile::Add, upload: response))
+      described_class.write_test
+    end
+  end
 end

--- a/spec/lib/moj_file/scan_spec.rb
+++ b/spec/lib/moj_file/scan_spec.rb
@@ -15,49 +15,49 @@ RSpec.describe MojFile::Scan do
   let(:resp) { instance_double(RestClient::Response, body: "Everything ok : true\n") }
   let(:infected) { instance_double(RestClient::Response, body: "Infected\n") }
 
-  describe '.clean_file' do
+  describe '.healthcheck_clean' do
     it 'sends a simple file name to aid identifying these calls in the logs' do
       expect(described_class).
         to receive(:new).
         with(hash_including(filename: 'clean test')).and_return(
           instance_double(described_class, scan_clear?: true)
         )
-      described_class.clean_file
+      described_class.healthcheck_clean
     end
 
     it 'reports OK' do
       allow(RestClient).to receive(:post).and_return(resp)
-      expect(described_class.clean_file).to eq('OK')
+      expect(described_class.healthcheck_clean).to be_truthy
     end
 
     # It always uses the same test string, so this should not fail if the
     # scanner is working correctly.
     it 'reports FAILED' do
       allow(RestClient).to receive(:post).and_return(infected)
-      expect(described_class.clean_file).to eq('FAILED')
+      expect(described_class.healthcheck_clean).to be_falsey
     end
   end
 
-  describe '.trigger_alert' do
+  describe '.healthcheck_infected' do
     it 'sends a simple file name to aid identifying these calls in the logs' do
       expect(described_class).
         to receive(:new).
         with(hash_including(filename: 'eicar test')).and_return(
           instance_double(described_class, scan_clear?: false)
         )
-      described_class.trigger_alert
+      described_class.healthcheck_infected
     end
 
-    it 'reports OK' do
+    it 'reports true' do
       allow(RestClient).to receive(:post).and_return(infected)
-      expect(described_class.trigger_alert).to eq('OK')
+      expect(described_class.healthcheck_infected).to be_truthy
     end
 
     # It always uses the same test string, so this should not fail if the
     # scanner is working correctly.
-    it 'reports FAILED' do
+    it 'reports false' do
       allow(RestClient).to receive(:post).and_return(resp)
-      expect(described_class.trigger_alert).to eq('FAILED')
+      expect(described_class.healthcheck_infected).to be_falsey
     end
   end
 


### PR DESCRIPTION
Checks AV interactions for both clean and infected files and writes to the S3 bucket.  Any dependency failure results in an app healthcheck failure.