### PR TITLE
Revert back the expected virus scan result body.

### DIFF
--- a/lib/moj_file/scan.rb
+++ b/lib/moj_file/scan.rb
@@ -8,7 +8,7 @@ module MojFile
     SCANNER_URL = ENV.fetch('SCANNER_URL', 'http://clamav-rest:8080/scan').freeze
     EICAR_TEST = 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
     CLEAN_TEST = 'clear test file'
-    EXPECTED_CLEAR_RESPONSE = "Everything ok : true\n".freeze
+    EXPECTED_CLEAR_RESPONSE = "true\n".freeze
 
     attr_reader :filename, :dummy_file
 

--- a/lib/moj_file/scan.rb
+++ b/lib/moj_file/scan.rb
@@ -8,7 +8,6 @@ module MojFile
     SCANNER_URL = ENV.fetch('SCANNER_URL', 'http://clamav-rest:8080/scan').freeze
     EICAR_TEST = 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
     CLEAN_TEST = 'clear test file'
-    EXPECTED_CLEAR_RESPONSE = "true\n".freeze
 
     attr_reader :filename, :dummy_file
 
@@ -18,7 +17,7 @@ module MojFile
     end
 
     def scan_clear?
-      post.body.eql?(EXPECTED_CLEAR_RESPONSE)
+      post.body.match(/true/)
     end
 
     def self.healthcheck_infected

--- a/spec/features/add_a_file_spec.rb
+++ b/spec/features/add_a_file_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe MojFile::Add do
     # would remove the need for unit tests for these specific attributes.
     # However, webmock does not yet support this for multipart requests.
     stub_request(:post, "http://clamav-rest:8080/scan").
-      to_return(body: "Everything ok : true\n")
+      to_return(body: "true\n")
   }
 
   context 'successfully adding a file' do

--- a/spec/features/healthcheck/av_spec.rb
+++ b/spec/features/healthcheck/av_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe 'Healthcheck' do
     )[:dependencies][:external][:av]
   }
 
+  let(:clean_result) { "true\n" }
+
   before do
     allow(MojFile::S3).to receive(:status)
     stub_request(:put, /healthcheck\.docx/).to_return(status: 200)
@@ -30,7 +32,7 @@ RSpec.describe 'Healthcheck' do
         expect(RestClient).
           to receive(:post).
           twice.
-          and_return(double('response', body: MojFile::Scan::EXPECTED_CLEAR_RESPONSE))
+          and_return(double('response', body: clean_result))
       end
 
       specify do
@@ -44,7 +46,7 @@ RSpec.describe 'Healthcheck' do
         expect(RestClient).
           to receive(:post).
           twice.
-          and_return(double('response', body: MojFile::Scan::EXPECTED_CLEAR_RESPONSE))
+          and_return(double('response', body: clean_result))
       end
 
       specify do

--- a/spec/lib/moj_file/scan_spec.rb
+++ b/spec/lib/moj_file/scan_spec.rb
@@ -12,8 +12,11 @@ RSpec.describe MojFile::Scan do
     allow(RestClient).to receive(:post)
   }
 
-  let(:resp) { instance_double(RestClient::Response, body: "Everything ok : true\n") }
-  let(:infected) { instance_double(RestClient::Response, body: "Infected\n") }
+  let(:clean_result) { "true\n" }
+  let(:infected_result) { "false\n" }
+
+  let(:resp) { instance_double(RestClient::Response, body: clean_result) }
+  let(:infected) { instance_double(RestClient::Response, body: infected_result) }
 
   describe '.healthcheck_clean' do
     it 'sends a simple file name to aid identifying these calls in the logs' do
@@ -68,7 +71,7 @@ RSpec.describe MojFile::Scan do
 
     context 'clear' do
       before do
-        expect(resp).to receive(:body).and_return("Everything ok : true\n")
+        expect(resp).to receive(:body).and_return(clean_result)
       end
 
       it 'returns true' do
@@ -81,7 +84,7 @@ RSpec.describe MojFile::Scan do
 
     context 'infected' do
       before do
-        expect(resp).to receive(:body).and_return("Everything ok : false\n")
+        expect(resp).to receive(:body).and_return(infected_result)
       end
 
       it 'returns false' do
@@ -128,7 +131,7 @@ RSpec.describe MojFile::Scan do
       end
 
       it 'captures the response body from the post' do
-        expect(resp).to receive(:body).and_return("Everything ok : true\n")
+        expect(resp).to receive(:body).and_return(clean_result)
         rest_client_called.and_return(resp)
         scan_file
       end


### PR DESCRIPTION
The virus scan result body keeps changing from time to time so a very specific string
will fail. Currently the virus scanner is returning just 'true' or 'false'.