### PR TITLE
enable the app. to respond to /healthcheck.json

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -11,7 +11,7 @@ module MojFile
       set :show_exceptions, false
     end
 
-    get '/healthcheck' do
+    get '/healthcheck.?:format?' do
       checks = healthchecks
       {
         service_status: checks[:service_status],


### PR DESCRIPTION
This change makes the app respond to /healthcheck and
/healthcheck.[anything]
Enabling /healthcheck.json makes this app. consistent with our
other services.