### PR TITLE
Fix some fragile tests assuming a specific scanner URL.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 export AWS_ACCESS_KEY_ID=dummy key
 export AWS_SECRET_ACCESS_KEY=dummy access key
-export BUCKET_NAME=tax-tribs-doc-upload-test
 export AWS_REGION=eu-west-1
+export BUCKET_NAME=tax-tribs-doc-upload-test
+export SCANNER_URL=http://clamav-rest:8080/scan

--- a/lib/moj_file/scan.rb
+++ b/lib/moj_file/scan.rb
@@ -5,7 +5,7 @@ require 'pp'
 module MojFile
   class Scan
     # clamav-rest is remapped in docker-compose.yml
-    SCANNER_URL = ENV.fetch('SCANNER_URL', 'http://clamav-rest:8080/scan').freeze
+    DEFAULT_SCANNER_URL = 'http://clamav-rest:8080/scan'.freeze
     EICAR_TEST = 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
     CLEAN_TEST = 'clear test file'
 
@@ -28,10 +28,14 @@ module MojFile
       new(filename: 'clean test', data: CLEAN_TEST).scan_clear?
     end
 
+    def scanner_url
+      ENV.fetch('SCANNER_URL', DEFAULT_SCANNER_URL)
+    end
+
     private
 
     def post
-      RestClient.post(SCANNER_URL, name: filename, file: dummy_file, multipart: true)
+      RestClient.post(scanner_url, name: filename, file: dummy_file, multipart: true)
     end
   end
 end

--- a/spec/features/add_a_file_spec.rb
+++ b/spec/features/add_a_file_spec.rb
@@ -3,6 +3,8 @@ require_relative '../spec_helper'
 RSpec.describe MojFile::Add do
   let(:encoded_file_data) { 'QSBkb2N1bWVudCBib2R5\n' }
   let(:decoded_file_data) { 'A document body' }
+  let(:bucket_name) { 'uploader-test-bucket' }
+  let(:scanner_url) { 'http://my-test-scanner' }
 
   let(:params) {
     {
@@ -14,6 +16,8 @@ RSpec.describe MojFile::Add do
 
   before do
     allow(SecureRandom).to receive(:uuid).and_return(12345)
+    allow(ENV).to receive(:fetch).with('BUCKET_NAME').and_return(bucket_name)
+    allow(ENV).to receive(:fetch).with('SCANNER_URL', 'http://clamav-rest:8080/scan').and_return(scanner_url)
   end
 
   let!(:s3_stub) {
@@ -25,8 +29,7 @@ RSpec.describe MojFile::Add do
     # Ideally, I would match the request body for filename and data.  This
     # would remove the need for unit tests for these specific attributes.
     # However, webmock does not yet support this for multipart requests.
-    stub_request(:post, "http://clamav-rest:8080/scan").
-      to_return(body: "true\n")
+    stub_request(:post, "http://my-test-scanner").to_return(body: "true\n")
   }
 
   context 'successfully adding a file' do

--- a/spec/lib/moj_file/scan_spec.rb
+++ b/spec/lib/moj_file/scan_spec.rb
@@ -102,9 +102,14 @@ RSpec.describe MojFile::Scan do
       }
 
       let(:rest_client_called) { expect(RestClient).to receive(:post) }
+      let(:scanner_url) { 'http://my-test-scanner' }
+
+      before do
+        allow(ENV).to receive(:fetch).with('SCANNER_URL', 'http://clamav-rest:8080/scan').and_return(scanner_url)
+      end
 
       it 'is called with the correct endpoint' do
-        rest_client_called.with(MojFile::Scan::SCANNER_URL, anything).
+        rest_client_called.with('http://my-test-scanner', anything).
           and_return(resp)
         scan_file
       end


### PR DESCRIPTION
Now regardless of what the value of the SCANNER_URL is in a given environment,
the tests will produce deterministic results and not fail.

Also renamed env.example to .env.example (starting with a dot) for consistency with other projects.