### PR TITLE
Remove title parameter from "add a file" logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Request. If no collection_ref route parameter is provided, a new collection will
 ```ruby
 POST to '/?:collection_ref?/new'
 with a JSON payload
-{file_title: 'title', file_filename: 'filename', file_data: 'Base64 encoded file data'}
+{file_filename: 'filename', file_data: 'Base64 encoded file data'}
 ```
 
 Response:
@@ -49,7 +49,7 @@ When virus detected:
   
 When failure:
     422 status code
-    JSON body: { errors: ['file_title must be provided', 'file_filename must be provided', 'file_data must be provided'] }
+    JSON body: { errors: ['file_filename must be provided', 'file_data must be provided'] }
 ```
 
 ### Deleting files
@@ -79,7 +79,7 @@ Response:
 ```ruby
 When success:
     200 status code
-    JSON body: { collection: '12345', files: [{ key: '12345/test.doc', title: 'test.doc', last_modified: '2016-12-05T12:20:02.000Z' }] }
+    JSON body: { collection: '12345', files: [{ key: '12345/test.doc', last_modified: '2016-12-05T12:20:02.000Z' }] }
   
 When collection not found:
     404 status code

--- a/example_app/app.rb
+++ b/example_app/app.rb
@@ -24,7 +24,7 @@ module MojFileUploadExample
       end
 
       def file_args
-        {collection_ref: collection_ref, title: file[:name], filename: file[:filename], data: file_data}
+        {collection_ref: collection_ref, filename: file[:filename], data: file_data}
       end
 
       def log(msg)

--- a/example_app/views/list_files.haml
+++ b/example_app/views/list_files.haml
@@ -14,5 +14,5 @@
 - if files
   - files.each do |file|
     %p
-      = file[:title]
+      = file[:filename]
       = file[:last_modified]

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -7,14 +7,12 @@ module MojFile
     extend Forwardable
 
     attr_accessor :collection,
-      :title,
       :filename,
       :file_data,
       :errors
 
     def initialize(collection_ref:, params:)
       @collection = collection_ref || SecureRandom.uuid
-      @title = params.fetch('file_title', '')
       @filename = params.fetch('file_filename', '')
       @file_data = params.fetch('file_data', '')
       @errors = []
@@ -38,7 +36,6 @@ module MojFile
       # anything other than a successful call will raise an exception.
       new(collection_ref: 'healthcheck',
           params: {
-        'file_title' => 'Healthcheck Upload',
         'file_filename' => 'healthcheck.docx',
         'file_data' => 'QSBkb2N1bWVudCBib2R5' }
          ).upload
@@ -66,11 +63,8 @@ module MojFile
 
     def validate
       errors.tap { |e|
-        e << 'file_title must be provided' if title.empty?
         e << 'file_filename must be provided' if filename.empty?
-        if file_data.empty?
-          e << 'file_data must be provided'
-        end
+        e << 'file_data must be provided' if file_data.empty?
       }
     end
   end

--- a/spec/features/add_a_file_spec.rb
+++ b/spec/features/add_a_file_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe MojFile::Add do
 
   let(:params) {
     {
-      file_title: 'Test Upload',
       file_filename: 'testfile.docx',
       file_data: encoded_file_data
     }
@@ -50,7 +49,6 @@ RSpec.describe MojFile::Add do
       end
 
       describe 'json response body' do
-
         it 'contains the file key' do
           post '/new', params.to_json
           expect(last_response.body).to match(/\"key\":\"testfile.docx\"/)
@@ -83,12 +81,6 @@ RSpec.describe MojFile::Add do
   end
 
   context 'missing data' do
-    it 'returns a 422 if the title is missing' do
-      params.delete(:file_title)
-      post '/new', params.to_json
-      expect(last_response.status).to eq(422)
-    end
-
     it 'returns a 422 if the filename is missing' do
       params.delete(:file_filename)
       post '/new', params.to_json
@@ -102,12 +94,6 @@ RSpec.describe MojFile::Add do
     end
 
     describe 'json response body' do
-      it 'explains the title is missing' do
-        params.delete(:file_title)
-        post '/new', params.to_json
-        expect(last_response.body).to match(/\"errors\":\[\"file_title must be provided\"\]/)
-      end
-
       it 'explains the filename is missing' do
         params.delete(:file_filename)
         post '/new', params.to_json

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe MojFile::Add do
 
   let(:params) {
     {
-      'file_title' => 'Test Upload',
       'file_filename' => 'testfile.docx',
       'file_data' => encoded_file_data
     }
@@ -43,7 +42,6 @@ RSpec.describe MojFile::Add do
         to receive(:new).
         with(collection_ref: 'healthcheck',
              params: {
-                      'file_title' => 'Healthcheck Upload',
                       'file_filename' => 'healthcheck.docx',
                       'file_data' => 'QSBkb2N1bWVudCBib2R5'
                      }

--- a/test.sh
+++ b/test.sh
@@ -30,7 +30,7 @@ list_files() {
 }
 
 upload_clean_file() {
-  data="{\"file_title\":\"Test Upload\",\"file_filename\":\"testfile.docx\",\"file_data\":\"RW5jb2RlZCBkb2N1bWVudCBib2R5\\n\"}"
+  data="{\"file_filename\":\"testfile.docx\",\"file_data\":\"RW5jb2RlZCBkb2N1bWVudCBib2R5\\n\"}"
 
   curl -X POST \
     -H "Content-Type: application/json" \
@@ -42,7 +42,7 @@ function upload_infected_file() {
   # This is the eicar virus scanning test pattern (ClamAV will recognise this as infected, but it's not)
   # NB: 4\\ should be 4\ but something is escaping this when we pass it through sinatra/ruby/something
   eicar='X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*'
-  data="{\"file_title\":\"Infected Upload\",\"file_filename\":\"testfile2.docx\",\"file_data\":\"${eicar}\n\"}"
+  data="{\"file_filename\":\"testfile2.docx\",\"file_data\":\"${eicar}\n\"}"
 
   curl -X POST \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
This was originally intended to be stored as metadata, but ended up
never being used. We aren't storing it anywhere, so shouldn't have the
parameter anymore.