### PR TITLE
Add support for (a single level of) folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,24 @@ of any of the user's uploaded files. To this end;
 The uploader can list the uploaded files, and can delete any of them (so that the user
 can correct mistakes).
 
+At the root level of the bucket, the uploader creates _collections_, which are a group
+of related files. You can add files to a collection explicitly by specifying its name,
+or implicitly have it create a new collection by leaving out the name. Underneath
+collections, the uploader optionally supports a single level of (sub)_folders_.
+
 ## API documentation
 
-A [client gem](https://github.com/ministryofjustice/mojfile-uploader-api-client) has been published that simplifies the interaction with the uploader API.
+A [client gem](https://github.com/ministryofjustice/mojfile-uploader-api-client) has
+been published that simplifies the interaction with the uploader API from Ruby apps.
 
 ### Adding files
 
-Request. If no collection_ref route parameter is provided, a new collection will be created.
+Request. If no `collection_ref` route parameter is provided, a new collection will be created.
 
 ```ruby
 POST to '/?:collection_ref?/new'
 with a JSON payload
-{file_filename: 'filename', file_data: 'Base64 encoded file data'}
+{folder: 'subfolder', file_filename: 'filename', file_data: 'Base64 encoded file data'}
 ```
 
 Response:
@@ -41,7 +47,7 @@ Response:
 ```ruby
 When success:
     200 status code
-    JSON body: { collection: 'collection reference', key: 'filename' }
+    JSON body: { collection: 'collection reference', folder: 'subfolder', key: 'filename' }
   
 When virus detected:
     400 status code
@@ -57,7 +63,7 @@ When failure:
 Request:
 
 ```ruby
-DELETE to '/:collection_ref/:filename'
+DELETE to '/:collection_ref/?:folder?/:filename'
 ```
 
 Response:
@@ -71,7 +77,7 @@ Response:
 Request:
 
 ```ruby
-GET to '/:collection_ref'
+GET to '/:collection_ref/?:folder?'
 ```
 
 Response:
@@ -79,7 +85,7 @@ Response:
 ```ruby
 When success:
     200 status code
-    JSON body: { collection: '12345', files: [{ key: '12345/test.doc', last_modified: '2016-12-05T12:20:02.000Z' }] }
+    JSON body: { collection: '12345', folder: 'subfolder', files: [{ key: '12345/subfolder/test.doc', title: 'test.doc', last_modified: '2016-12-05T12:20:02.000Z' }] }
   
 When collection not found:
     404 status code

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -8,12 +8,14 @@ module MojFile
 
     attr_accessor :collection,
       :filename,
+      :folder,
       :file_data,
       :errors
 
     def initialize(collection_ref:, params:)
       @collection = collection_ref || SecureRandom.uuid
       @filename = params.fetch('file_filename', '')
+      @folder = params.fetch('folder', nil)
       @file_data = params.fetch('file_data', '')
       @errors = []
     end
@@ -58,7 +60,7 @@ module MojFile
     end
 
     def object
-      s3.bucket(bucket_name).object([collection, filename].join('/'))
+      s3.bucket(bucket_name).object([collection, folder, filename].compact.join('/'))
     end
 
     def validate

--- a/lib/moj_file/delete.rb
+++ b/lib/moj_file/delete.rb
@@ -3,14 +3,16 @@ module MojFile
     include MojFile::S3
 
     attr_accessor :collection,
+      :folder,
       :file
 
     def self.delete!(*args)
       new(*args).delete!
     end
 
-    def initialize(collection:, file:)
+    def initialize(collection:, folder:, file:)
       @collection = collection
+      @folder = folder
       @file = file
     end
 
@@ -25,7 +27,7 @@ module MojFile
     end
 
     def object
-      s3.bucket(bucket_name).object([collection, file].join('/'))
+      s3.bucket(bucket_name).object([collection, folder, file].compact.join('/'))
     end
   end
 end

--- a/lib/moj_file/list.rb
+++ b/lib/moj_file/list.rb
@@ -2,19 +2,21 @@ module MojFile
   class List
     include MojFile::S3
 
-    attr_accessor :collection
+    attr_accessor :collection, :folder
 
     def self.call(*args)
       new(*args)
     end
 
-    def initialize(collection_ref)
+    def initialize(collection_ref, folder:)
       @collection = collection_ref
+      @folder = folder
     end
 
     def files
       {
         collection: collection,
+        folder: folder,
         files: map_files
       }
     end
@@ -36,7 +38,7 @@ module MojFile
     end
 
     def prefix
-      "#{collection}/"
+      [collection, folder].compact.join('/') + '/'
     end
 
     def bucket_name

--- a/spec/features/add_a_file_spec.rb
+++ b/spec/features/add_a_file_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe MojFile::Add do
 
   let(:params) {
     {
+      folder: 'subfolder',
       file_filename: 'testfile.docx',
       file_data: encoded_file_data
     }
@@ -20,7 +21,7 @@ RSpec.describe MojFile::Add do
   end
 
   let!(:s3_stub) {
-    stub_request(:put, /uploader-test-bucket.+s3.+amazonaws\.com\/12345\/testfile.docx/).
+    stub_request(:put, /uploader-test-bucket.+s3.+amazonaws\.com\/12345\/subfolder\/testfile.docx/).
       with(body: decoded_file_data)
   }
 
@@ -58,12 +59,37 @@ RSpec.describe MojFile::Add do
           post '/new', params.to_json
           expect(last_response.body).to match(/\"collection\":12345/)
         end
+
+        it 'contains the folder name' do
+          post '/new', params.to_json
+          expect(last_response.body).to match(/\"folder\":\"subfolder\"/)
+        end
+      end
+    end
+
+    context 'without a folder' do
+      before do
+        stub_request(:put, /uploader-test-bucket.+s3.+amazonaws\.com\/ABC123\/testfile.docx/)
+      end
+
+      let(:params) { super().merge('folder' => nil) }
+
+      it 'returns a 200' do
+        post '/ABC123/new', params.to_json
+        expect(last_response.status).to eq(200)
+      end
+
+      describe 'json response body' do
+        it 'contains the folder as null' do
+          post '/ABC123/new', params.to_json
+          expect(last_response.body).to match(/\"folder\":null/)
+        end
       end
     end
 
     context 'reusing a collection_reference' do
       before do
-        stub_request(:put, /uploader-test-bucket.+s3.+amazonaws\.com\/ABC123\/testfile.docx/)
+        stub_request(:put, /uploader-test-bucket.+s3.+amazonaws\.com\/ABC123\/subfolder\/testfile.docx/)
       end
 
       it 'returns a 200' do

--- a/spec/features/delete_a_file_spec.rb
+++ b/spec/features/delete_a_file_spec.rb
@@ -2,20 +2,41 @@ require 'spec_helper'
 
 RSpec.describe MojFile::Delete do
   context 'the file exists' do
-    let!(:s3_stub) {
-      stub_request(:delete, /uploader-test-bucket.+amazonaws\.com\/ABC123\/testfile\.docx/).
-      to_return(status: 204)
-    }
+    context 'and is in a subfolder' do
+      let!(:s3_stub) {
+        stub_request(:delete, /uploader-test-bucket.+amazonaws\.com\/ABC123\/subfolder\/testfile\.docx/).
+        to_return(status: 204)
+      }
 
-    describe '#delete' do
-      before do
-        delete '/ABC123/testfile.docx'
+      describe '#delete' do
+        before do
+          delete '/ABC123/subfolder/testfile.docx'
+        end
+
+        describe 'it deletes the file' do
+          it { expect(s3_stub).to have_been_requested }
+          # This mirrors S3's success response.
+          it { expect(last_response.status).to eq(204) }
+        end
       end
+    end
 
-      describe 'it deletes the file' do
-        it { expect(s3_stub).to have_been_requested }
-        # This mirrors S3's success response.
-        it { expect(last_response.status).to eq(204) }
+    context 'and is not in a subfolder' do
+      let!(:s3_stub) {
+        stub_request(:delete, /uploader-test-bucket.+amazonaws\.com\/ABC123\/testfile\.docx/).
+        to_return(status: 204)
+      }
+
+      describe '#delete' do
+        before do
+          delete '/ABC123/testfile.docx'
+        end
+
+        describe 'it deletes the file' do
+          it { expect(s3_stub).to have_been_requested }
+          # This mirrors S3's success response.
+          it { expect(last_response.status).to eq(204) }
+        end
       end
     end
   end

--- a/spec/features/list_files_spec.rb
+++ b/spec/features/list_files_spec.rb
@@ -7,9 +7,61 @@ RSpec.describe MojFile::List do
   }
 
   context 'happy paths' do
-    describe 'the collection has files' do
-      let(:aws_response) {
-        <<-XML
+    context 'when a subfolder is provided' do
+      describe 'the collection has files' do
+        let(:aws_response) {
+          <<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <Name>bucket</Name>
+    <KeyCount>2</KeyCount>
+    <Contents>
+        <Key>12345/subfolder/solicitor.docx</Key>
+        <LastModified>2016-10-12T17:50:30.000Z</LastModified>
+    </Contents>
+    <Contents>
+        <Key>12345/subfolder/hmrc_appeal.docx</Key>
+        <LastModified>2016-10-12T17:50:30.000Z</LastModified>
+    </Contents>
+</ListBucketResult>
+          XML
+        }
+
+        let(:expected_response) {
+          {
+            collection: '12345',
+            folder: 'subfolder',
+            files: [
+              {
+                key: '12345/subfolder/solicitor.docx',
+                title: 'solicitor.docx',
+                last_modified: '2016-10-12T17:50:30.000Z'
+              },
+              {
+                key: '12345/subfolder/hmrc_appeal.docx',
+                title: 'hmrc_appeal.docx',
+                last_modified: '2016-10-12T17:50:30.000Z'
+              }
+          ]
+          }.to_json
+        }
+
+        it 'returns a 200 ok' do
+          get '/12345/subfolder'
+          expect(last_response.status).to eq(200)
+        end
+
+        it 'returns a list of the files in a collection' do
+          get '/12345/subfolder'
+          expect(last_response.body).to eq(expected_response)
+        end
+      end
+    end
+
+    context 'when no subfolder is provided' do
+      describe 'the collection has files' do
+        let(:aws_response) {
+          <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
     <Name>bucket</Name>
@@ -23,36 +75,37 @@ RSpec.describe MojFile::List do
         <LastModified>2016-10-12T17:50:30.000Z</LastModified>
     </Contents>
 </ListBucketResult>
-        XML
-      }
+          XML
+        }
 
-      let(:expected_response) {
-        {
-          collection: '12345',
-          files: [
-            {
-              key: '12345/solicitor.docx',
-              title: 'solicitor.docx',
-              last_modified: '2016-10-12T17:50:30.000Z'
-            },
-            {
-              key: '12345/hmrc_appeal.docx',
-              title: 'hmrc_appeal.docx',
-              last_modified: '2016-10-12T17:50:30.000Z'
-            }
-        ]
-        }.to_json
-      }
+        let(:expected_response) {
+          {
+            collection: '12345',
+            folder: nil,
+            files: [
+              {
+                key: '12345/solicitor.docx',
+                title: 'solicitor.docx',
+                last_modified: '2016-10-12T17:50:30.000Z'
+              },
+              {
+                key: '12345/hmrc_appeal.docx',
+                title: 'hmrc_appeal.docx',
+                last_modified: '2016-10-12T17:50:30.000Z'
+              }
+          ]
+          }.to_json
+        }
 
+        it 'returns a 200 ok' do
+          get '/12345'
+          expect(last_response.status).to eq(200)
+        end
 
-      it 'returns a 200 ok' do
-        get '/12345'
-        expect(last_response.status).to eq(200)
-      end
-
-      it 'returns a list of the files in a collection' do
-        get '/12345'
-        expect(last_response.body).to eq(expected_response)
+        it 'returns a list of the files in a collection' do
+          get '/12345'
+          expect(last_response.body).to eq(expected_response)
+        end
       end
     end
 

--- a/spec/lib/moj_file/list_spec.rb
+++ b/spec/lib/moj_file/list_spec.rb
@@ -2,11 +2,12 @@ require 'spec_helper'
 
 RSpec.describe MojFile::List do
   let(:collection_ref) { '12345' }
+  let(:folder) { 'subfolder' }
   let(:s3) { instance_double(Aws::S3::Resource, bucket: bucket) }
   let(:bucket) { double('Bucket', objects: objects) }
-  let(:objects) { [double('Object', key: '12345/test123.txt', title: '12345/test123.txt', last_modified: '2016-12-01T16:26:44.000Z')] }
+  let(:objects) { [double('Object', key: '12345/subfolder/test123.txt', last_modified: '2016-12-01T16:26:44.000Z')] }
 
-  subject { described_class.new(collection_ref) }
+  subject { described_class.new(collection_ref, folder: folder) }
 
   describe '#files' do
     before do
@@ -16,16 +17,37 @@ RSpec.describe MojFile::List do
     let(:expected_files_hash) {
       {
         collection: collection_ref,
+        folder: folder,
         files: [
-            {key: '12345/test123.txt', title: 'test123.txt', last_modified: '2016-12-01T16:26:44.000Z'}
+          {key: '12345/subfolder/test123.txt', title: 'test123.txt', last_modified: '2016-12-01T16:26:44.000Z'}
         ]
       }
     }
 
     it 'list S3 bucket objects by their collection reference including a trailing slash' do
-      expect(bucket).to receive(:objects).with(prefix: '12345/')
+      expect(bucket).to receive(:objects).with(prefix: '12345/subfolder/')
       files = subject.files
       expect(files).to eq(expected_files_hash)
+    end
+
+    context 'when no folder is given' do
+      let(:expected_files_hash) {
+        {
+          collection: collection_ref,
+          folder: folder,
+          files: [
+            {key: '12345/test123.txt', title: 'test123.txt', last_modified: '2016-12-01T16:26:44.000Z'}
+          ]
+        }
+      }
+      let(:objects) { [double('Object', key: '12345/test123.txt', last_modified: '2016-12-01T16:26:44.000Z')] }
+      let(:folder) { nil }
+
+      it 'list S3 bucket objects by their collection reference including a trailing slash' do
+        expect(bucket).to receive(:objects).with(prefix: '12345/')
+        files = subject.files
+        expect(files).to eq(expected_files_hash)
+      end
     end
   end
 end


### PR DESCRIPTION
Add support for folders underneath collections to allow applications
using the uploader to be a bit more organised.

- Add support for folders in add/delete/list
- Update README with minor bits of architectural information