### PR TITLE
set the encryption flag when uploading to S3

### DIFF
--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -21,7 +21,7 @@ module MojFile
     end
 
     def upload
-      object.put(body: decoded_file_data)
+      object.put(body: decoded_file_data, server_side_encryption: 'AES256')
     end
 
     def valid?

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe MojFile::Add do
     end
   end
 
+  describe 'encrypting' do
+    subject(:adder) { described_class.new(collection_ref: 'foo', params: params) }
+    let(:s3_object) { double('S3', put: true) }
+
+    before do
+      stub_request(:put, "https://uploader-test-bucket.s3-eu-west-1.amazonaws.com/foo/testfile.docx")
+      # TODO: stubbing methods on the test subject is gross. We should fix this
+      allow(adder).to receive_message_chain(:s3, :bucket, :object).and_return(s3_object)
+    end
+
+    it 'set the encryption to AES256' do
+      expect(s3_object).to receive(:put).with(body: 'A document body', server_side_encryption: 'AES256')
+      adder.upload
+    end
+  end
+
   describe '.write_test' do # These are mutant kills
     it 'uploads a test file successfully' do
       stub_request(:put, /\/healthcheck\/healthcheck\.docx/).to_return(status: 200)


### PR DESCRIPTION
Every time we add an object to the S3 bucket, set 
encryption to AES256. The object will be transparently 
decrypted whenever it is downloaded from the bucket.

All this does is protect us in the event of physical theft
of the hard disks where the data is stored, but it's trivial
to do, so we may as well do it.