### PR TITLE
Ensure various attacks cannot be persisted via S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'pry'
 gem 'puma'
 gem 'rake'
 gem 'rest-client'
+gem 'sanitize'
 gem 'sinatra'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
       equalizer (~> 0.0.9)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.20160826)
@@ -89,6 +90,8 @@ GEM
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
+    nokogumbo (1.4.10)
+      nokogiri
     parallel (1.9.0)
     parser (2.3.1.2)
       ast (~> 2.2)
@@ -138,6 +141,10 @@ GEM
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
+    sanitize (4.4.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -190,6 +197,7 @@ DEPENDENCIES
   rspec
   rubocop
   rubocop-rspec
+  sanitize
   simplecov
   sinatra
   webmock


### PR DESCRIPTION
This mirrors the logic used in the datacapture app to ensure that
information passed to third parties is not compromised.