### PR TITLE
Ensure we can diagnose upload failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 .env.test
+log

--- a/app.rb
+++ b/app.rb
@@ -54,7 +54,8 @@ module MojFile
 
     post '/?:collection_ref?/new' do |collection_ref|
       add = Add.new(collection_ref: collection_ref,
-                    params: body_params)
+                    params: body_params,
+                    logger: logger)
 
       clear = add.scan_clear?
 
@@ -77,6 +78,19 @@ module MojFile
     end
 
     helpers do
+      def logger
+        @logger ||= LogStashLogger.new(logger_config)
+      end
+
+      def logger_config
+        env = ENV['RACK_ENV']
+        if env == 'production'
+          { type: :stdout }
+        else
+          { type: :file, path: "log/#{env}.log", sync: true }
+        end
+      end
+
       def body_params
         JSON.parse(request.body.read)
       end

--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,17 @@ require 'logstash-logger'
 require_relative 'lib/moj_file'
 require 'pry'
 
+module LogStashLogger
+  module Formatter
+    class PrettyJson < Base
+      def call(severity, time, progname, message)
+        super
+        "#{JSON.pretty_generate(@event)}\n"
+      end
+    end
+  end
+end
+
 module MojFile
   class Uploader < Sinatra::Base
     configure do
@@ -84,10 +95,11 @@ module MojFile
 
       def logger_config
         env = ENV['RACK_ENV']
+        defaults = { formatter: LogStashLogger::Formatter::PrettyJson }
         if env == 'production'
-          { type: :stdout }
+          defaults.merge!(type: :stdout)
         else
-          { type: :file, path: "log/#{env}.log", sync: true }
+          defaults.merge!({ type: :file, path: "log/#{env}.log", sync: true })
         end
       end
 

--- a/lib/dummy_logger.rb
+++ b/lib/dummy_logger.rb
@@ -1,0 +1,9 @@
+#:nocov:
+class DummyLogger
+  def info(*anything)
+  end
+
+  def error(*anything)
+  end
+end
+#:nocov:

--- a/lib/moj_file.rb
+++ b/lib/moj_file.rb
@@ -5,6 +5,7 @@ require_relative 'moj_file/add'
 require_relative 'moj_file/delete'
 require_relative 'moj_file/list'
 require_relative 'moj_file/scan'
+require_relative 'dummy_logger'
 
 module MojFile
 end

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -28,7 +28,7 @@ module MojFile
     def upload
       object.put(body: decoded_file_data, server_side_encryption: 'AES256').tap { log_result }
     rescue => error
-      log_result(error: error.to_s)
+      log_result(error: error.message, backtrace: error.backtrace)
       false
     end
 

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -26,13 +26,10 @@ module MojFile
     end
 
     def upload
-      @put = { success: true }
-      object.put(body: decoded_file_data, server_side_encryption: 'AES256')
+      object.put(body: decoded_file_data, server_side_encryption: 'AES256').tap { log_result }
     rescue => error
-      @put = { success: false, error: error.to_s }
+      log_result(error: error.to_s)
       false
-    ensure
-      log_result(@put)
     end
 
     def valid?
@@ -55,12 +52,12 @@ module MojFile
 
     private
 
-    def log_result(params)
+    def log_result(params = {})
       params.merge!(
         { filename: [collection, folder, filename].join('/'),
           filesize: file_data.size }
       )
-      params.fetch(:success) ? logger.info(params) : logger.error(params)
+      params.fetch(:error, nil) ? logger.error(params) : logger.info(params)
     end
 
     def sanitize(value)

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -57,8 +57,7 @@ module MojFile
 
     def log_result(params)
       params.merge!(
-        { timestamp: Time.now,
-          filename: [collection, folder, filename].join('/'),
+        { filename: [collection, folder, filename].join('/'),
           filesize: file_data.size }
       )
       params.fetch(:success) ? logger.info(params) : logger.error(params)

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -8,12 +8,13 @@ module MojFile
     extend Forwardable
 
     attr_accessor :collection,
+      :errors,
+      :file_data,
       :filename,
       :folder,
-      :file_data,
-      :errors
+      :logger
 
-    def initialize(collection_ref:, params:)
+    def initialize(collection_ref:, params:, logger: DummyLogger.new)
       @collection = collection_ref || SecureRandom.uuid
       # The nils and blank strings are necessary to ensure that `app#new`
       # raises the correct errors on validation.
@@ -21,10 +22,17 @@ module MojFile
       @folder = params.fetch('folder', nil)
       @file_data = params.fetch('file_data', '')
       @errors = []
+      @logger = logger
     end
 
     def upload
+      @put = { success: true }
       object.put(body: decoded_file_data, server_side_encryption: 'AES256')
+    rescue => error
+      @put = { success: false, error: error.to_s }
+      false
+    ensure
+      log_result(@put)
     end
 
     def valid?
@@ -37,18 +45,24 @@ module MojFile
     end
 
     def self.write_test
-      # It started checking for .success? but that isn't acutually necessary as
-      # anything other than a successful call will raise an exception.
+      # Errors get trapped and logged in `#upload`
       new(collection_ref: 'healthcheck',
           params: {
         'file_filename' => 'healthcheck.docx',
         'file_data' => 'QSBkb2N1bWVudCBib2R5' }
          ).upload
-    rescue Aws::S3::Errors::ServiceError
-      false
     end
 
     private
+
+    def log_result(params)
+      params.merge!(
+        { timestamp: Time.now,
+          filename: [collection, folder, filename].join('/'),
+          filesize: file_data.size }
+      )
+      params.fetch(:success) ? logger.info(params) : logger.error(params)
+    end
 
     def sanitize(value)
       CGI.escapeHTML(

--- a/spec/lib/moj_file/add/upload_spec.rb
+++ b/spec/lib/moj_file/add/upload_spec.rb
@@ -89,8 +89,13 @@ RSpec.describe MojFile::Add, '#upload' do
         subject.upload
       end
 
-      it 'logs the error' do
+      it 'logs the error message' do
         expect(logger).to receive(:error).with(hash_including(error: 'StandardError'))
+        subject.upload
+      end
+
+      it 'logs the backtrace' do
+        expect(logger).to receive(:error).with(hash_including(backtrace: an_instance_of(Array)))
         subject.upload
       end
 

--- a/spec/lib/moj_file/add/upload_spec.rb
+++ b/spec/lib/moj_file/add/upload_spec.rb
@@ -75,11 +75,6 @@ RSpec.describe MojFile::Add, '#upload' do
         subject.upload
       end
 
-      it 'logs success' do
-        expect(logger).to receive(:info).with(hash_including(success: true))
-        subject.upload
-      end
-
       include_examples 'common logging actions', :info
     end
 
@@ -91,11 +86,6 @@ RSpec.describe MojFile::Add, '#upload' do
 
       it 'logs at error level' do
         expect(logger).to receive(:error)
-        subject.upload
-      end
-
-      it 'logs failure' do
-        expect(logger).to receive(:error).with(hash_including(success: false))
         subject.upload
       end
 

--- a/spec/lib/moj_file/add/upload_spec.rb
+++ b/spec/lib/moj_file/add/upload_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+# These may be blank, or the cause of an error, but they still get logged.
+RSpec.shared_examples 'common logging actions' do |log_level|
+  it 'logs the timestamp' do
+    expect(logger).to receive(log_level).with(hash_including(timestamp: Time.parse('2017-03-20 00:00:00')))
+    subject.upload
+  end
+
+  it 'logs the filename' do
+    expect(logger).to receive(log_level).with(hash_including(filename: 'ABC123/some_folder/testfile.docx'))
+    subject.upload
+  end
+
+  it 'logs the size of file_data in bytes' do
+    expect(logger).to receive(log_level).with(hash_including(filesize: 22))
+    subject.upload
+  end
+end
+
+RSpec.describe MojFile::Add, '#upload' do
+  let(:encoded_file_data) { 'QSBkb2N1bWVudCBib2R5\n' }
+  let(:decoded_file_data) { 'A document body' }
+  let(:params) {
+    {
+      'file_filename' => 'testfile.docx',
+      'folder' => 'some_folder',
+      'file_data' => encoded_file_data
+    }
+  }
+
+  let(:s3_response) { double.as_null_object }
+
+  subject {
+    described_class.new(collection_ref: nil, params: params)
+  }
+
+  before do
+    allow(SecureRandom).to receive(:uuid).and_return('ABC123')
+  end
+
+  it 'puts the decoded file data to the bucket' do
+    expect(s3_response).to receive(:put).with(hash_including(body: 'A document body')).and_return(true)
+    allow(subject).to receive(:object).and_return(s3_response)
+    subject.upload
+  end
+
+  it 'tells S3 to encrypt the stored data using AES256' do
+    expect(s3_response).to receive(:put).with(hash_including(server_side_encryption: 'AES256')).and_return(true)
+    allow(subject).to receive(:object).and_return(s3_response)
+    subject.upload
+  end
+
+  it 'returns false when an error occurs' do
+    allow(subject).to receive(:object).and_raise(StandardError)
+    expect(subject.upload).to eq(false)
+  end
+
+  it 'returns true when the write is successful' do
+    allow(s3_response).to receive(:put).and_return(true)
+    allow(subject).to receive(:object).and_return(s3_response)
+    expect(subject.upload).to eq(true)
+  end
+
+  describe 'logging' do
+    let(:logger) { double.as_null_object }
+
+    before do
+      subject.logger = logger
+    end
+
+    context 'success' do
+      before do
+        allow(Time).to receive(:now).and_return(Time.parse('2017-03-20 00:00:00'))
+        allow(s3_response).to receive(:put).and_return(true)
+        allow(subject).to receive(:object).and_return(s3_response)
+      end
+
+      it 'logs at info level' do
+        expect(logger).to receive(:info)
+        subject.upload
+      end
+
+      it 'logs success' do
+        expect(logger).to receive(:info).with(hash_including(success: true))
+        subject.upload
+      end
+
+      include_examples 'common logging actions', :info
+    end
+
+    context 'errors' do
+      before do
+        allow(Time).to receive(:now).and_return(Time.parse('2017-03-20 00:00:00'))
+        allow(SecureRandom).to receive(:uuid).and_return('ABC123')
+        allow(subject).to receive(:object).and_raise(StandardError)
+      end
+
+      it 'logs at error level' do
+        expect(logger).to receive(:error)
+        subject.upload
+      end
+
+      it 'logs failure' do
+        expect(logger).to receive(:error).with(hash_including(success: false))
+        subject.upload
+      end
+
+      it 'logs the error' do
+        expect(logger).to receive(:error).with(hash_including(error: 'StandardError'))
+        subject.upload
+      end
+
+      include_examples 'common logging actions', :error
+    end
+  end
+end

--- a/spec/lib/moj_file/add/upload_spec.rb
+++ b/spec/lib/moj_file/add/upload_spec.rb
@@ -2,11 +2,6 @@ require 'spec_helper'
 
 # These may be blank, or the cause of an error, but they still get logged.
 RSpec.shared_examples 'common logging actions' do |log_level|
-  it 'logs the timestamp' do
-    expect(logger).to receive(log_level).with(hash_including(timestamp: Time.parse('2017-03-20 00:00:00')))
-    subject.upload
-  end
-
   it 'logs the filename' do
     expect(logger).to receive(log_level).with(hash_including(filename: 'ABC123/some_folder/testfile.docx'))
     subject.upload
@@ -71,7 +66,6 @@ RSpec.describe MojFile::Add, '#upload' do
 
     context 'success' do
       before do
-        allow(Time).to receive(:now).and_return(Time.parse('2017-03-20 00:00:00'))
         allow(s3_response).to receive(:put).and_return(true)
         allow(subject).to receive(:object).and_return(s3_response)
       end
@@ -91,7 +85,6 @@ RSpec.describe MojFile::Add, '#upload' do
 
     context 'errors' do
       before do
-        allow(Time).to receive(:now).and_return(Time.parse('2017-03-20 00:00:00'))
         allow(SecureRandom).to receive(:uuid).and_return('ABC123')
         allow(subject).to receive(:object).and_raise(StandardError)
       end

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe MojFile::Add do
   let(:params) {
     {
       'file_filename' => 'testfile.docx',
+      'folder' => 'some_folder',
       'file_data' => encoded_file_data
     }
   }
@@ -20,7 +21,6 @@ RSpec.describe MojFile::Add do
       expect(mocked_params).to receive(:fetch).with('file_filename', '')
       described_class.new(collection_ref: nil, params: mocked_params)
     end
-
 
     specify 'escapes html that was not otherwise removed' do
       expect(CGI).to receive(:escapeHTML).and_return(value)


### PR DESCRIPTION
We were not logging previously on this app.  That made it difficult to
diagnose the intermittent connection failures we see with S3 in some
environments.  This implements logging for uploads and for the
healthcheck write test (which uses the same upload method in the
background), which should give us some insight into the connection
problems.