### PR TITLE
rename /healthcheck.json to /status.json

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -22,8 +22,8 @@ module MojFile
       set :show_exceptions, false
     end
 
-    get '/healthcheck.?:format?' do
-      checks = healthchecks
+    get '/status.?:format?' do
+      checks = statuschecks
       {
         service_status: checks[:service_status],
         dependencies: {
@@ -109,10 +109,10 @@ module MojFile
 
       # Can't see a good way around this.
       # rubocop:disable Metrics/CyclomaticComplexity
-      def healthchecks
+      def statuschecks
         write_test = Add.write_test
-        detect_infected = Scan.healthcheck_infected
-        clean_file = Scan.healthcheck_clean
+        detect_infected = Scan.statuscheck_infected
+        clean_file = Scan.statuscheck_clean
         service_status = if write_test && detect_infected && clean_file
                            'ok'
                          else

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -43,9 +43,9 @@ module MojFile
 
     def self.write_test
       # Errors get trapped and logged in `#upload`
-      new(collection_ref: 'healthcheck',
+      new(collection_ref: 'status',
           params: {
-        'file_filename' => 'healthcheck.docx',
+        'file_filename' => 'status.docx',
         'file_data' => 'QSBkb2N1bWVudCBib2R5' }
          ).upload
     end

--- a/lib/moj_file/scan.rb
+++ b/lib/moj_file/scan.rb
@@ -20,11 +20,11 @@ module MojFile
       post.body.match(/true/)
     end
 
-    def self.healthcheck_infected
+    def self.statuscheck_infected
       !new(filename: 'eicar test', data: EICAR_TEST).scan_clear?
     end
 
-    def self.healthcheck_clean
+    def self.statuscheck_clean
       new(filename: 'clean test', data: CLEAN_TEST).scan_clear?
     end
 

--- a/spec/features/status/app_spec.rb
+++ b/spec/features/status/app_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe 'Service status' do
 
   before do
     allow(MojFile::S3).to receive(:status)
-    allow(MojFile::Scan).to receive(:healthcheck_infected).and_return(true)
-    allow(MojFile::Scan).to receive(:healthcheck_clean).and_return(true)
-    stub_request(:put, /healthcheck\.docx/).to_return(status: 200)
-    get '/healthcheck'
+    allow(MojFile::Scan).to receive(:statuscheck_infected).and_return(true)
+    allow(MojFile::Scan).to receive(:statuscheck_clean).and_return(true)
+    stub_request(:put, /status\.docx/).to_return(status: 200)
+    get '/status'
   end
 
   describe 'happy path' do

--- a/spec/features/status/av_spec.rb
+++ b/spec/features/status/av_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-RSpec.describe 'Healthcheck' do
+RSpec.describe 'Status' do
   let(:av) {
     JSON.parse(
       last_response.body,
@@ -12,7 +12,7 @@ RSpec.describe 'Healthcheck' do
 
   before do
     allow(MojFile::S3).to receive(:status)
-    stub_request(:put, /healthcheck\.docx/).to_return(status: 200)
+    stub_request(:put, /status\.docx/).to_return(status: 200)
   end
 
   describe 'happy path' do
@@ -22,7 +22,7 @@ RSpec.describe 'Healthcheck' do
       end
 
       specify do
-        get '/healthcheck'
+        get '/status'
         expect(av[:detected_infected_file]).to eq('ok')
       end
     end
@@ -36,7 +36,7 @@ RSpec.describe 'Healthcheck' do
       end
 
       specify do
-        get '/healthcheck'
+        get '/status'
         expect(av[:detected_infected_file]).to eq('failed')
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe 'Healthcheck' do
       end
 
       specify do
-        get '/healthcheck'
+        get '/status'
         expect(av[:passed_clean_file]).to eq('ok')
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe 'Healthcheck' do
       end
 
       specify do
-        get '/healthcheck'
+        get '/status'
         expect(av[:passed_clean_file]).to eq('failed')
       end
     end

--- a/spec/features/status/s3_spec.rb
+++ b/spec/features/status/s3_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../../spec_helper'
 
-RSpec.describe 'Healthcheck' do
+RSpec.describe 'Status' do
   let(:parsed_response) {
     JSON.parse(
       last_response.body,
@@ -13,14 +13,14 @@ RSpec.describe 'Healthcheck' do
   }
 
   before do
-    allow(MojFile::Scan).to receive(:healthcheck_infected)
-    allow(MojFile::Scan).to receive(:healthcheck_clean)
+    allow(MojFile::Scan).to receive(:statuscheck_infected)
+    allow(MojFile::Scan).to receive(:statuscheck_clean)
   end
 
   context 'Successful write test' do
     let(:decoded_file_data) { 'A document body' }
     let!(:write_stub) {
-      stub_request(:put, /healthcheck\.docx/).
+      stub_request(:put, /status\.docx/).
       with(body: decoded_file_data).
       to_return(status: 200)
     }
@@ -31,7 +31,7 @@ RSpec.describe 'Healthcheck' do
 
     describe '[:external][:s3][:write_test]' do
       specify do
-        get '/healthcheck'
+        get '/status'
         expect(s3_subkey[:write_test]).to eq('ok')
       end
     end
@@ -39,12 +39,12 @@ RSpec.describe 'Healthcheck' do
     describe '[:service_status]' do
       before do
         allow(MojFile::S3).to receive(:status)
-        allow(MojFile::Scan).to receive(:healthcheck_infected).and_return(true)
-        allow(MojFile::Scan).to receive(:healthcheck_clean).and_return(true)
+        allow(MojFile::Scan).to receive(:statuscheck_infected).and_return(true)
+        allow(MojFile::Scan).to receive(:statuscheck_clean).and_return(true)
       end
 
       specify do
-        get '/healthcheck'
+        get '/status'
         expect(parsed_response[:service_status]).to eq('ok')
       end
     end
@@ -53,7 +53,7 @@ RSpec.describe 'Healthcheck' do
   context 'Failed write test' do
     let(:decoded_file_data) { 'A document body' }
     let!(:write_stub) {
-      stub_request(:put, /healthcheck\.docx/).
+      stub_request(:put, /status\.docx/).
       with(body: decoded_file_data).
       to_return(status: 422)
     }
@@ -64,14 +64,14 @@ RSpec.describe 'Healthcheck' do
 
     describe '[:external][:s3][:write_test]' do
       specify do
-        get '/healthcheck'
+        get '/status'
         expect(s3_subkey[:write_test]).to eq('failed')
       end
     end
 
     describe '[:service_status]' do
       specify do
-        get '/healthcheck'
+        get '/status'
         expect(parsed_response[:service_status]).to eq('failed')
       end
     end
@@ -111,7 +111,7 @@ RSpec.describe 'Healthcheck' do
     }
 
     before do
-      stub_request(:put, /healthcheck\.docx/).to_return(status: 200)
+      stub_request(:put, /status\.docx/).to_return(status: 200)
     end
 
     describe 'default region [:external][:s3][:eu_west_1]' do
@@ -122,7 +122,7 @@ RSpec.describe 'Healthcheck' do
 
       describe 'if the endpoint reports that the service is working, the key' do
         specify do
-          get '/healthcheck'
+          get '/status'
           expect(s3_subkey[:eu_west_1]).
             to eq('Service is operating normally')
         end
@@ -135,7 +135,7 @@ RSpec.describe 'Healthcheck' do
         end
 
         specify do
-          get '/healthcheck'
+          get '/status'
           expect(s3_subkey[:eu_west_1]).to eq('N/A')
         end
       end
@@ -153,7 +153,7 @@ RSpec.describe 'Healthcheck' do
 
       describe 'if the endpoint reports that the service is working, the key' do
         specify do
-          get '/healthcheck'
+          get '/status'
           expect(s3_subkey[:us_east_1]).
             to eq('Service is operating normally')
         end
@@ -166,7 +166,7 @@ RSpec.describe 'Healthcheck' do
         end
 
         specify do
-          get '/healthcheck'
+          get '/status'
           expect(s3_subkey[:us_east_1]).to eq('N/A')
         end
       end

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -101,12 +101,12 @@ RSpec.describe MojFile::Add do
 
   describe '.write_test' do # These are mutant kills
     it 'uploads a test file successfully' do
-      stub_request(:put, /\/healthcheck\/healthcheck\.docx/).to_return(status: 200)
+      stub_request(:put, /\/status\/status\.docx/).to_return(status: 200)
       expect(described_class.write_test).to be_truthy
     end
 
     it 'fails to upload a test file' do
-      stub_request(:put, /\/healthcheck\/healthcheck\.docx/).to_return(status: 422)
+      stub_request(:put, /\/status\/status\.docx/).to_return(status: 422)
       expect(described_class.write_test).to be(false)
     end
 
@@ -114,9 +114,9 @@ RSpec.describe MojFile::Add do
       response = double(:response, successful?: true)
       expect(described_class).
         to receive(:new).
-        with(collection_ref: 'healthcheck',
+        with(collection_ref: 'status',
              params: {
-        'file_filename' => 'healthcheck.docx',
+        'file_filename' => 'status.docx',
         'file_data' => 'QSBkb2N1bWVudCBib2R5'
       }
             ).and_return(instance_double(MojFile::Add, upload: response))

--- a/spec/lib/moj_file/s3_spec.rb
+++ b/spec/lib/moj_file/s3_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe MojFile::S3 do
     end
   end
 
-  # These are mutant-kills. See features/healthcheck_spec_s3.rb for operational examples.
+  # These are mutant-kills. See features/status_spec_s3.rb for operational examples.
   describe '.status' do
     let(:status_response) {
       <<-XML

--- a/spec/lib/moj_file/scan_spec.rb
+++ b/spec/lib/moj_file/scan_spec.rb
@@ -18,49 +18,49 @@ RSpec.describe MojFile::Scan do
   let(:resp) { instance_double(RestClient::Response, body: clean_result) }
   let(:infected) { instance_double(RestClient::Response, body: infected_result) }
 
-  describe '.healthcheck_clean' do
+  describe '.statuscheck_clean' do
     it 'sends a simple file name to aid identifying these calls in the logs' do
       expect(described_class).
         to receive(:new).
         with(hash_including(filename: 'clean test')).and_return(
           instance_double(described_class, scan_clear?: true)
         )
-      described_class.healthcheck_clean
+      described_class.statuscheck_clean
     end
 
     it 'reports OK' do
       allow(RestClient).to receive(:post).and_return(resp)
-      expect(described_class.healthcheck_clean).to be_truthy
+      expect(described_class.statuscheck_clean).to be_truthy
     end
 
     # It always uses the same test string, so this should not fail if the
     # scanner is working correctly.
     it 'reports FAILED' do
       allow(RestClient).to receive(:post).and_return(infected)
-      expect(described_class.healthcheck_clean).to be_falsey
+      expect(described_class.statuscheck_clean).to be_falsey
     end
   end
 
-  describe '.healthcheck_infected' do
+  describe '.statuscheck_infected' do
     it 'sends a simple file name to aid identifying these calls in the logs' do
       expect(described_class).
         to receive(:new).
         with(hash_including(filename: 'eicar test')).and_return(
           instance_double(described_class, scan_clear?: false)
         )
-      described_class.healthcheck_infected
+      described_class.statuscheck_infected
     end
 
     it 'reports true' do
       allow(RestClient).to receive(:post).and_return(infected)
-      expect(described_class.healthcheck_infected).to be_truthy
+      expect(described_class.statuscheck_infected).to be_truthy
     end
 
     # It always uses the same test string, so this should not fail if the
     # scanner is working correctly.
     it 'reports false' do
       allow(RestClient).to receive(:post).and_return(resp)
-      expect(described_class.healthcheck_infected).to be_falsey
+      expect(described_class.statuscheck_infected).to be_falsey
     end
   end
 


### PR DESCRIPTION
"healthcheck" has a specific meaning for the
platforms team (should this endpoint receive
traffic from the load-balancer), so we should be
using /status.json for our system status endpoints