### PR TITLE
Add Sentry error notifications.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'puma'
 gem 'rake'
 gem 'rest-client'
 gem 'sanitize'
+gem 'sentry-raven'
 gem 'sinatra'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     equalizer (0.0.11)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
     fuubar (2.2.0)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
@@ -67,6 +69,7 @@ GEM
       equalizer (~> 0.0.9)
       ice_nine (~> 0.11.0)
       procto (~> 0.0.2)
+    multipart-post (2.0.0)
     mutant (0.8.11)
       abstract_type (~> 0.0.7)
       adamantium (~> 0.2.0)
@@ -145,6 +148,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
       nokogumbo (~> 1.4.1)
+    sentry-raven (2.3.0)
+      faraday (>= 0.7.6, < 1.0)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -198,6 +203,7 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   sanitize
+  sentry-raven
   simplecov
   sinatra
   webmock

--- a/app.rb
+++ b/app.rb
@@ -18,8 +18,7 @@ end
 module MojFile
   class Uploader < Sinatra::Base
     configure do
-      set :raise_errors, true
-      set :show_exceptions, false
+      set :raise_errors, false
     end
 
     get '/status.?:format?' do

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,8 @@
+require 'raven'
 require 'sinatra'
 require_relative 'app'
+
+# Will use SENTRY_DSN environment variable if set
+use Raven::Rack
 
 run MojFile::Uploader


### PR DESCRIPTION
On development it will continue showing a nice stack trace on the browser, but on production
environments, it will not show stack trace (only a generic error such as (Internal Server Error)
and the exception will be sent to Sentry.