### PR TITLE
Logging delete actions, and a bit of refactor.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -83,7 +83,10 @@ module MojFile
     end
 
     delete '/:collection_ref/?:folder?/:filename' do |collection_ref, folder, filename|
-      Delete.delete!(collection: collection_ref, folder: folder, file: filename)
+      Delete.delete!(collection: collection_ref,
+                     folder: folder,
+                     filename: filename,
+                     logger: logger)
       status(204)
     end
 

--- a/lib/moj_file.rb
+++ b/lib/moj_file.rb
@@ -1,5 +1,6 @@
 require 'aws-sdk'
 require_relative 'moj_file/s3'
+require_relative 'moj_file/logging'
 
 require_relative 'moj_file/add'
 require_relative 'moj_file/delete'

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -5,7 +5,10 @@ require 'sanitize'
 module MojFile
   class Add
     include MojFile::S3
+    include MojFile::Logging
     extend Forwardable
+
+    ACTION_NAME = 'Add'
 
     attr_accessor :collection,
       :errors,
@@ -54,10 +57,12 @@ module MojFile
 
     def log_result(params = {})
       params.merge!(
-        { filename: [collection, folder, filename].join('/'),
-          filesize: file_data.size }
+        {
+          filename: object_name,
+          filesize: file_data.size
+        }
       )
-      params.fetch(:error, nil) ? logger.error(params) : logger.info(params)
+      super
     end
 
     def sanitize(value)
@@ -77,14 +82,6 @@ module MojFile
 
     def decoded_file_data
       Base64.decode64(file_data)
-    end
-
-    def bucket_name
-      ENV.fetch('BUCKET_NAME')
-    end
-
-    def object
-      s3.bucket(bucket_name).object([collection, folder, filename].compact.join('/'))
     end
 
     def validate

--- a/lib/moj_file/delete.rb
+++ b/lib/moj_file/delete.rb
@@ -1,33 +1,28 @@
 module MojFile
   class Delete
     include MojFile::S3
+    include MojFile::Logging
+
+    ACTION_NAME = 'Delete'
 
     attr_accessor :collection,
       :folder,
-      :file
+      :filename,
+      :logger
 
     def self.delete!(*args)
       new(*args).delete!
     end
 
-    def initialize(collection:, folder:, file:)
+    def initialize(collection:, folder:, filename:, logger: DummyLogger.new)
       @collection = collection
       @folder = folder
-      @file = file
+      @filename = filename
+      @logger = logger
     end
 
     def delete!
-      object.delete
-    end
-
-    private
-
-    def bucket_name
-      ENV.fetch('BUCKET_NAME')
-    end
-
-    def object
-      s3.bucket(bucket_name).object([collection, folder, file].compact.join('/'))
+      object.delete.tap { log_result(filename: object_name) }
     end
   end
 end

--- a/lib/moj_file/logging.rb
+++ b/lib/moj_file/logging.rb
@@ -1,0 +1,10 @@
+module MojFile
+  module Logging
+    private
+
+    def log_result(params)
+      params.merge!(action: self.class::ACTION_NAME)
+      params.fetch(:error, nil) ? logger.error(params) : logger.info(params)
+    end
+  end
+end

--- a/lib/moj_file/s3.rb
+++ b/lib/moj_file/s3.rb
@@ -16,5 +16,19 @@ module MojFile
 		rescue NoMethodError
 			'N/A'
     end
+
+    def object
+      s3.bucket(bucket_name).object(object_name)
+    end
+
+    private
+
+    def bucket_name
+      ENV.fetch('BUCKET_NAME')
+    end
+
+    def object_name
+      [collection, folder, filename].compact.join('/')
+    end
   end
 end

--- a/spec/lib/moj_file/add/upload_spec.rb
+++ b/spec/lib/moj_file/add/upload_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 # These may be blank, or the cause of an error, but they still get logged.
 RSpec.shared_examples 'common logging actions' do |log_level|
+  it 'logs the action' do
+    expect(logger).to receive(log_level).with(hash_including(action: 'Add'))
+    subject.upload
+  end
+
   it 'logs the filename' do
     expect(logger).to receive(log_level).with(hash_including(filename: 'ABC123/some_folder/testfile.docx'))
     subject.upload

--- a/spec/lib/moj_file/delete_spec.rb
+++ b/spec/lib/moj_file/delete_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe MojFile::Delete do
+  let(:args) {
+    {
+      collection: 'collection',
+      folder: 'some_folder',
+      filename: 'testfile.docx'
+    }
+  }
+
+  subject { described_class.new(args) }
+
+  describe 'deleting' do
+    let(:s3_object) { double('S3', delete: true) }
+
+    before do
+      allow(subject).to receive_message_chain(:s3, :bucket, :object).and_return(s3_object)
+    end
+
+    it 'deletes the s3 object' do
+      expect(s3_object).to receive(:delete)
+      subject.delete!
+    end
+
+    describe 'logging' do
+      let(:logger) { double.as_null_object }
+
+      before do
+        subject.logger = logger
+      end
+
+      it 'logs at info level the details of the file' do
+        expect(logger).to receive(:info).with(
+          hash_including(filename: 'collection/some_folder/testfile.docx', action: 'Delete')
+        )
+        subject.delete!
+      end
+    end
+  end
+end


### PR DESCRIPTION
For deletions, S3 will never fail even if the file doesn't exist, so there is no try-catch
as in the put actions.

A bit of refactor to extract and reorganize common functionality.

https://www.pivotaltracker.com/story/show/142219825