### PR TITLE
Stop breaking the file names after upload

### DIFF
--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -73,9 +73,8 @@ module MojFile
     end
 
     def sanitize(value)
-      CGI.escapeHTML(
-        Sanitize.fragment(value, Sanitize::Config::RESTRICTED)
-      ).gsub('*', '&#42;').
+      Sanitize.fragment(value).
+      gsub('*', '&#42;').
       gsub('=', '&#61;').
       gsub('-', '&dash;').
       gsub('%', '&#37;').

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -25,48 +25,43 @@ RSpec.describe MojFile::Add do
       described_class.new(collection_ref: nil, params: mocked_params)
     end
 
-    specify 'escapes html that was not otherwise removed' do
-      expect(CGI).to receive(:escapeHTML).and_return(value)
-      described_class.new(collection_ref: nil, params: params)
-    end
-
     specify 'removes most html tags' do
-      expect(Sanitize).to receive(:fragment).with(params['file_filename'], anything).and_return(value)
+      expect(Sanitize).to receive(:fragment).with(params['file_filename']).and_return(value)
       described_class.new(collection_ref: nil, params: params)
     end
 
     specify 'scrubs *' do
-      allow(CGI).to receive(:escapeHTML).and_return(value)
+      allow(Sanitize).to receive(:fragment).and_return(value)
       expect(value).to receive(:gsub).with('*', anything)
       described_class.new(collection_ref: nil, params: params)
     end
 
     specify 'scrubs =' do
-      allow(CGI).to receive(:escapeHTML).and_return(value)
+      allow(Sanitize).to receive(:fragment).and_return(value)
       expect(value).to receive(:gsub).with('=', anything)
       described_class.new(collection_ref: nil, params: params)
     end
 
     specify 'scrubs -' do # kills SQL comments
-      allow(CGI).to receive(:escapeHTML).and_return(value)
+      allow(Sanitize).to receive(:fragment).and_return(value)
       expect(value).to receive(:gsub).with('-', anything)
       described_class.new(collection_ref: nil, params: params)
     end
 
     specify 'scrubs %' do
-      allow(CGI).to receive(:escapeHTML).and_return(value)
+      allow(Sanitize).to receive(:fragment).and_return(value)
       expect(value).to receive(:gsub).with('%', anything)
       described_class.new(collection_ref: nil, params: params)
     end
 
     specify 'removes `drop table` case-insensitively'do
-      allow(CGI).to receive(:escapeHTML).and_return(value)
+      allow(Sanitize).to receive(:fragment).and_return(value)
       expect(value).to receive(:gsub).with(/drop\s+table/i, anything)
       described_class.new(collection_ref: nil, params: params)
     end
 
     specify 'removes `insert into` case-insensitively'do
-      allow(CGI).to receive(:escapeHTML).and_return(value)
+      allow(Sanitize).to receive(:fragment).and_return(value)
       expect(value).to receive(:gsub).with(/insert\s+into/i, anything)
       described_class.new(collection_ref: nil, params: params)
     end


### PR DESCRIPTION
The html escaping has been causing problems.  This should fix the
problem while still offering some protection against XSS and common SQL
injection paths.