### PR TITLE
Stop breaking legitimate filenames

### DIFF
--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -76,7 +76,6 @@ module MojFile
       Sanitize.fragment(value).
       gsub('*', '&#42;').
       gsub('=', '&#61;').
-      gsub('-', '&dash;').
       gsub('%', '&#37;').
       gsub(/drop\s+table/i, '').
       gsub(/insert\s+into/i, '')

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe MojFile::Add do
       described_class.new(collection_ref: nil, params: params)
     end
 
-    specify 'scrubs -' do # kills SQL comments
-      allow(Sanitize).to receive(:fragment).and_return(value)
-      expect(value).to receive(:gsub).with('-', anything)
-      described_class.new(collection_ref: nil, params: params)
-    end
-
     specify 'scrubs %' do
       allow(Sanitize).to receive(:fragment).and_return(value)
       expect(value).to receive(:gsub).with('%', anything)


### PR DESCRIPTION
Dashes are allowed characters in URLs.  The removed gsub was causing the
removal logic to break when filenames contained dashes.