### PR TITLE
Make the uploader more tolerant of s3 errors

### DIFF
--- a/lib/moj_file/s3.rb
+++ b/lib/moj_file/s3.rb
@@ -2,12 +2,21 @@ require 'nokogiri'
 
 module MojFile
   module S3
+    # 3 is the default number of retries[1]. I have chosen a conservative 5
+    # here as, according to the AWS docs[2], retries use exponential backoff
+    # and I do not want the increasing time between attempts to set off the
+    # client timeout.
+    #
+    # [1](http://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html#initialize-instance_method)
+    # [2](http://docs.aws.amazon.com/general/latest/gr/api-retries.html) it uses
+    RETRY_LIMIT = 5.freeze
     REGION = ENV.fetch('AWS_REGION', 'eu-west-1').freeze
     STATUS_RSS_ENDPOINT =
       "https://status.aws.amazon.com/rss/s3-#{REGION}.rss".freeze
 
     def s3
-      Aws::S3::Resource.new(region: REGION)
+      client = Aws::S3::Client.new(region: REGION, retry_limit: RETRY_LIMIT, compute_checksums: false)
+      Aws::S3::Resource.new(client: client)
     end
 
     def self.status


### PR DESCRIPTION
While the exact nature of the errors are not currently clear, it seems
likely that they result from a combination of S3 checksumming errors and
the small number of retries allocated to resolve these.  My reasoning is
that it has been reported that, despite the errors, the files are often
successfully uploaded.

This commit turns off all unnecessary checksumming and increases the
number of retires from three to five.  Hopefully, these combined
changes will resolve the issue.