### PR TITLE
Resolve sentry issues

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -22,10 +22,6 @@ module MojFile
               passed_clean_file: checks[:passed_clean_file]
             },
             s3: {
-              # This is here so ops do not have to go looking for the AWS S3
-              # status if the write_test fails. It does not change the
-              # service_status
-              S3::REGION.tr('-','_') => S3.status,
               write_test: checks[:write_test]
             }
           }

--- a/app.rb
+++ b/app.rb
@@ -80,6 +80,10 @@ module MojFile
       status(204)
     end
 
+    error do
+      { message: env['sinatra.error'].message }.to_json
+    end
+
     helpers do
       def logger
         @logger ||= LogStashLogger.new(logger_config)

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -34,7 +34,7 @@ module MojFile
       object.put(body: decoded_file_data, server_side_encryption: 'AES256').tap { log_result }
     rescue => error
       log_result(error: error.inspect, backtrace: error.backtrace)
-      false
+      raise error
     end
 
     def valid?

--- a/lib/moj_file/add.rb
+++ b/lib/moj_file/add.rb
@@ -34,7 +34,7 @@ module MojFile
       object.put(body: decoded_file_data, server_side_encryption: 'AES256').tap { log_result }
     rescue => error
       log_result(error: error.inspect, backtrace: error.backtrace)
-      raise error
+      raise
     end
 
     def valid?
@@ -52,7 +52,7 @@ module MojFile
     end
 
     def self.write_test
-      # Errors get trapped and logged in `#upload`
+      # Errors get logged in `#upload`
       new(collection_ref: 'status',
           params: {
         'file_filename' => 'status.docx',

--- a/lib/moj_file/s3.rb
+++ b/lib/moj_file/s3.rb
@@ -11,19 +11,10 @@ module MojFile
     # [2](http://docs.aws.amazon.com/general/latest/gr/api-retries.html) it uses
     RETRY_LIMIT = 5.freeze
     REGION = ENV.fetch('AWS_REGION', 'eu-west-1').freeze
-    STATUS_RSS_ENDPOINT =
-      "https://status.aws.amazon.com/rss/s3-#{REGION}.rss".freeze
 
     def s3
       client = Aws::S3::Client.new(region: REGION, retry_limit: RETRY_LIMIT, compute_checksums: false)
       Aws::S3::Resource.new(client: client)
-    end
-
-    def self.status
-      status = RestClient.get(STATUS_RSS_ENDPOINT)
-      Nokogiri.parse(status.body).xpath("//item/title").first.text
-		rescue NoMethodError
-			'N/A'
     end
 
     def object

--- a/spec/features/status_spec.rb
+++ b/spec/features/status_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe 'Parsed status response' do
   let(:s3) { resp[:dependencies][:external][:s3] }
 
   before do
-    allow(MojFile::S3).to receive(:status)
     allow(MojFile::Add).to receive(:write_test)
     allow(MojFile::Scan).to receive(:statuscheck_clean)
     allow(MojFile::Scan).to receive(:statuscheck_infected)

--- a/spec/lib/moj_file/add/upload_spec.rb
+++ b/spec/lib/moj_file/add/upload_spec.rb
@@ -4,17 +4,17 @@ require 'spec_helper'
 RSpec.shared_examples 'common logging actions' do |log_level|
   it 'logs the action' do
     expect(logger).to receive(log_level).with(hash_including(action: 'Add'))
-    subject.upload
+    subject.upload rescue StandardError
   end
 
   it 'logs the filename' do
     expect(logger).to receive(log_level).with(hash_including(filename: 'ABC123/some_folder/testfile.docx'))
-    subject.upload
+    subject.upload rescue StandardError
   end
 
   it 'logs the size of file_data in bytes' do
     expect(logger).to receive(log_level).with(hash_including(filesize: 22))
-    subject.upload
+    subject.upload rescue StandardError
   end
 end
 
@@ -49,11 +49,6 @@ RSpec.describe MojFile::Add, '#upload' do
     expect(s3_response).to receive(:put).with(hash_including(server_side_encryption: 'AES256')).and_return(true)
     allow(subject).to receive(:object).and_return(s3_response)
     subject.upload
-  end
-
-  it 'returns false when an error occurs' do
-    allow(subject).to receive(:object).and_raise(StandardError)
-    expect(subject.upload).to eq(false)
   end
 
   it 'returns true when the write is successful' do
@@ -91,17 +86,17 @@ RSpec.describe MojFile::Add, '#upload' do
 
       it 'logs at error level' do
         expect(logger).to receive(:error)
-        subject.upload
+        subject.upload rescue StandardError
       end
 
       it 'logs the error message' do
         expect(logger).to receive(:error).with(hash_including(error: /StandardError/))
-        subject.upload
+        subject.upload rescue StandardError
       end
 
       it 'logs the backtrace' do
         expect(logger).to receive(:error).with(hash_including(backtrace: an_instance_of(Array)))
-        subject.upload
+        subject.upload rescue StandardError
       end
 
       include_examples 'common logging actions', :error

--- a/spec/lib/moj_file/add_spec.rb
+++ b/spec/lib/moj_file/add_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe MojFile::Add do
     }
   }
 
+  describe '#upload' do
+    it 're-raises the error' do
+      stub_request(:put, /\/status\/status\.docx/).to_return(status: 422)
+      expect{ described_class.write_test }.to raise_error(Aws::S3::Errors::Http422Error)
+    end
+  end
+
   describe '#filename' do
     let(:value) { double.as_null_object }
 
@@ -116,9 +123,9 @@ RSpec.describe MojFile::Add do
       expect(described_class.write_test).to be_truthy
     end
 
-    it 'fails to upload a test file' do
+    it 're-raises the exception if it fails to upload a test file' do
       stub_request(:put, /\/status\/status\.docx/).to_return(status: 422)
-      expect(described_class.write_test).to be(false)
+      expect{ described_class.write_test }.to raise_error(Aws::S3::Errors::Http422Error)
     end
 
     it 'receives the parameters required for the test file' do
@@ -127,9 +134,9 @@ RSpec.describe MojFile::Add do
         to receive(:new).
         with(collection_ref: 'status',
              params: {
-        'file_filename' => 'status.docx',
-        'file_data' => 'QSBkb2N1bWVudCBib2R5'
-      }
+              'file_filename' => 'status.docx',
+              'file_data' => 'QSBkb2N1bWVudCBib2R5'
+             }
             ).and_return(instance_double(MojFile::Add, upload: response))
       described_class.write_test
     end

--- a/spec/lib/moj_file/s3_spec.rb
+++ b/spec/lib/moj_file/s3_spec.rb
@@ -122,27 +122,5 @@ RSpec.describe MojFile::S3 do
       </rss>
       XML
     }
-
-    it 'calls the AWS endpoint' do
-      expect(RestClient).to receive(:get).with(described_class::STATUS_RSS_ENDPOINT)
-      described_class.status
-    end
-
-    it 'parses the response' do
-      allow(RestClient).to receive(:get).and_return(double('response', body: status_response))
-      expect(Nokogiri).to receive(:parse)
-      described_class.status
-    end
-
-    it 'returns the most current item' do
-      allow(RestClient).to receive(:get).and_return(double('response', body: status_response))
-      expect(described_class.status).to eq('Service is operating normally')
-    end
-
-    # This would be the error if the xpath didn't exist.
-    it 'returns N/A if Nokogiri raises a NoMethodError' do
-      allow(RestClient).to receive(:get).and_return(double('response', body: ''))
-      expect(described_class.status).to eq('N/A')
-    end
   end
 end


### PR DESCRIPTION
Sorts a number of issues that are preventing errors from making it into sentry or making it difficult to track what's going on with the ones that do make it to sentry.