### PR TITLE
Enable running via docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,9 @@ services:
     links:
       - clamav-rest
   clamav:
-    # https://github.com/ministryofjustice/moj-clamav-daemon
-    image: registry.service.dsd.io/ministryofjustice/clamav:0.1.0
+     build: https://github.com/ministryofjustice/moj-clamav-daemon.git
   clamav-rest:
-    # https://github.com/ministryofjustice/moj-clamav-rest
-    image: registry.service.dsd.io/ministryofjustice/clamav-rest:0.1.0
+    build: https://github.com/ministryofjustice/moj-clamav-rest.git
     links:
       - clamav:clamav-server
     environment:


### PR DESCRIPTION
The docker-compose is currently fetching the dependencies from a private registry, restricting the use of the tool to the ones with access to that private registry.

This PR changes the docker-compose config to allow anyone to run the mojfile-uploader via docker-compose.